### PR TITLE
feat(ui): modern restyle baseline (Argo CD-aligned)

### DIFF
--- a/ui/patches/argo-ui+1.0.0.patch
+++ b/ui/patches/argo-ui+1.0.0.patch
@@ -28,8 +28,198 @@ index 04e5bd1..58a419e 100644
      RenderReturn,
 -    FormField as FormFieldHOC,
  } from './form/compat';
+diff --git a/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.scss b/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.scss
+index ef3a3d7..78bd4a2 100644
+--- a/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.scss
++++ b/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.scss
+@@ -2,7 +2,8 @@
+ @import 'node_modules/xterm/css/xterm';
+ 
+ .logs-viewer {
+-    font: normal 13px/1.2 'Courier', sans-serif;
++    font: normal 13px/1.2 'Courier New', Courier, 'Liberation Mono', monospace;
++    letter-spacing: normal;
+     line-height: 20px;
+     height: 100%;
+     overflow: hidden;
+diff --git a/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.tsx b/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.tsx
+index fc7bc35..ecddac3 100644
+--- a/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.tsx
++++ b/node_modules/argo-ui/src/components/logs-viewer/logs-viewer.tsx
+@@ -29,6 +29,10 @@ export class LogsViewer extends React.Component<LogsViewerProps> {
+         this.terminal = new Terminal({
+             scrollback: 99999,
+             allowTransparency: true,
++            fontFamily: "'Courier New', Courier, 'Liberation Mono', monospace",
++            fontSize: 13,
++            letterSpacing: 0,
++            lineHeight: 1.2,
+             theme: {
+                 background: 'transparent',
+                 foreground: '#495763',
+diff --git a/node_modules/argo-ui/src/components/nav-bar/nav-bar.scss b/node_modules/argo-ui/src/components/nav-bar/nav-bar.scss
+index afc295f..19a4016 100644
+--- a/node_modules/argo-ui/src/components/nav-bar/nav-bar.scss
++++ b/node_modules/argo-ui/src/components/nav-bar/nav-bar.scss
+@@ -4,45 +4,96 @@ $nav-break-height-md: 900px;
+ $nav-break-height-sm: 746px;
+ 
+ .nav-bar {
++    // Thin navy ICON rail (~60px), keeping argo-ui's original narrow width so it
++    // never overlaps or dominates page content. Width is exposed as the CSS var
++    // --awf-nav-width so the app frame (.page padding-left, .page__top-bar left,
++    // .workflows-toolbar width) can stay in lockstep via the same token.
+     position: fixed;
+     top: 0;
+     left: 0;
+     bottom: 0;
+-    padding-top: 160px;
++    display: flex;
++    flex-direction: column;
++    padding-top: 0;
+     z-index: $nav-z-index;
+-    width: $nav-width;
+-    background: linear-gradient(to bottom, #333, #444, #555, #666, #999);
+-    box-shadow: inset -2px 0 4px 0 rgba(0,0,0,0.59);
++    width: var(--awf-nav-width, 60px);
++    background: #0f2733; // Argo CD navy ($sidebar-bg), NOT near-black, NOT a gradient
++    box-shadow: inset -1px 0 0 0 rgba(0,0,0,0.25);
+ 
+ 
+     &__logo {
+-        position: absolute;
+-        top: 0;
+-        left: 0;
+-        right: 0;
+-        padding: 8px 6px;
++        position: relative;
++        display: flex;
++        flex-direction: column;
++        align-items: center;
++        justify-content: center;
++        flex: 0 0 auto;
++        box-sizing: border-box;
++        // Keep the mark inside the 60px rail: 36px img + 2*12px = 60px, no spill
++        // past the right edge. Transparent fill + clip so no pale box sits behind
++        // the orange octopus on the navy rail (the white notch is gone).
++        padding: 12px 12px 8px;
++        overflow: hidden;
++        background: transparent;
+ 
+         img {
+-            max-width: 104%;
++            // Argo Workflows' ORANGE octopus mark — render UNTOUCHED on the navy
++            // rail (no invert/recolor; orange reads cleanly on #0f2733).
++            width: 36px;
++            max-width: 36px;
+         }
+     }
+ 
++    // Scrollable nav column below the logo block.
++    &__items {
++        flex: 1 1 auto;
++        overflow-y: auto;
++        overflow-x: hidden;
++        padding: 4px 0;
++    }
++
+     &__item {
+         position: relative;
+-        margin: 20px 0;
+-        padding-right: 3px;
+-        font-size: 34px;
+-        color: $white-color;
++        // Thin icon RAIL: each row is icon-only and CENTERED; the full title is
++        // supplied on hover by the wrapping Tooltip, so no inline label is shown.
++        display: flex;
++        align-items: center;
++        justify-content: center;
++        height: 44px;
++        margin: 4px 0;
++        padding: 0;
++        color: #818d94; // Argo CD $deselected-text (muted slate)
+         text-align: center;
+         cursor: pointer;
+         border-left: 3px solid transparent;
++        transition: color 0.15s ease, background-color 0.15s ease;
++
++        &-icon {
++            flex: 0 0 auto;
++            font-size: 22px;
++            text-align: center;
++            transition: color 0.15s ease;
++        }
++
++        // The label markup stays in the DOM (router-shim hunk) but is hidden in
++        // the thin rail; the Tooltip already shows the title on hover.
++        &-label {
++            display: none;
++        }
+ 
+         &.active {
+-            border-color: $argo-color-teal-5;
++            color: $white-color; // active icon brightens to white
++            background-color: rgba(255, 255, 255, 0.04);
++            border-color: $argo-color-teal-5; // calm teal-6 left-border marker
++
++            .nav-bar__item-icon {
++                color: $white-color;
++            }
+         }
+ 
+         &:hover {
+-            color: $argo-color-gray-4;
++            color: $white-color; // label brightens toward white on hover
++            background-color: rgba(255, 255, 255, 0.06);
+         }
+ 
+       &:focus {
+@@ -86,24 +137,30 @@ $nav-break-height-sm: 746px;
+     }
+ 
+     &__version {
+-        font-size: smaller;
+-        color: $argo-color-gray-2;
+-        overflow: hidden;
++        display: block;
++        font-size: 9px;
++        padding: 2px 4px 6px;
++        color: #9aa6ad; // muted slate, centered under the logo (AA ~6.2:1 on navy)
+         text-align: center;
++        line-height: 1.25;
++        // Argo CD shows a muted version under the logo. The full string (e.g.
++        // "latest+sha.dirty") is too wide for the 60px rail on one line, so WRAP
++        // it onto two or three short centered lines and break the long build
++        // token cleanly instead of clipping it to "lates...". The full string is
++        // also carried in a native `title` tooltip (markup hunk above).
++        max-width: 100%;
++        white-space: normal;
++        overflow-wrap: anywhere;
++        word-break: break-word;
++        text-overflow: clip;
++        overflow: visible;
+     }
+ }
+ 
++// COMPACT (>=10 items): tighten the icon-row rhythm a touch in the thin rail.
+ .nav-bar.nav-bar--compact {
+-    .nav-bar__logo {
+-        img {
+-            display: block;
+-            max-width: 85%;
+-            margin: 0 auto;
+-        }
+-    }
+-
+     .nav-bar__item {
+-        margin: 10px 0;
+-        font-size: 25px;
++        height: 36px;
++        margin: 1px 0;
+     }
+ }
 diff --git a/node_modules/argo-ui/src/components/nav-bar/nav-bar.tsx b/node_modules/argo-ui/src/components/nav-bar/nav-bar.tsx
-index 9213aa7..77280ca 100644
+index 9213aa7..06487ea 100644
 --- a/node_modules/argo-ui/src/components/nav-bar/nav-bar.tsx
 +++ b/node_modules/argo-ui/src/components/nav-bar/nav-bar.tsx
 @@ -1,7 +1,7 @@
@@ -41,7 +231,7 @@ index 9213aa7..77280ca 100644
  import {Tooltip} from '../tooltip/tooltip';
  
  require('./nav-bar.scss');
-@@ -21,11 +21,9 @@ export function isActiveRoute(locationPath: string, path: string) {
+@@ -21,13 +21,11 @@ export function isActiveRoute(locationPath: string, path: string) {
  }
  
  export const NavBar: React.FunctionComponent<NavBarProps> = (props: NavBarProps) => {
@@ -54,17 +244,30 @@ index 9213aa7..77280ca 100644
 +    const location = useLocation();
 +    const locationPath = location.pathname;
      const navBarStyle = {
-         ...(props.style?.backgroundColor && {background: `linear-gradient(to bottom, ${props.style?.backgroundColor}, #999`}),
+-        ...(props.style?.backgroundColor && {background: `linear-gradient(to bottom, ${props.style?.backgroundColor}, #999`}),
++        background: props.style?.backgroundColor || '#0f2733',
      };
-@@ -39,7 +37,7 @@ export const NavBar: React.FunctionComponent<NavBarProps> = (props: NavBarProps)
+     return (
+         <div className={classNames('nav-bar', {
+@@ -35,12 +33,15 @@ export const NavBar: React.FunctionComponent<NavBarProps> = (props: NavBarProps)
+         })} style={navBarStyle}>
+             <div className='nav-bar__logo'>
+                 <img src='assets/images/logo.png' alt='Argo'/>
+-                <div className='nav-bar__version'>{props.version && props.version()}</div>
++                <div className='nav-bar__version' ref={(el) => { if (el) { el.setAttribute('title', el.textContent || ''); } }}>{props.version && props.version()}</div>
++            </div>
++            <div className='nav-bar__items'>
                  {(props.items || []).map((item) => (
                      <Tooltip content={item.title} placement='right' arrow={true} key={item.path + item.title}>
                          <div className={classNames('nav-bar__item', { active: isActiveRoute(locationPath, item.path) })}
 -                            onClick={() => context.router.history.push(item.path)}>
+-                            <i className={item.iconClassName}/>
 +                            onClick={() => navigate(item.path)}>
-                             <i className={item.iconClassName}/>
++                            <i className={classNames('nav-bar__item-icon', item.iconClassName)}/>
++                            <span className='nav-bar__item-label'>{item.title}</span>
                          </div>
                      </Tooltip>
+                 ))}
 diff --git a/node_modules/argo-ui/src/context.tsx b/node_modules/argo-ui/src/context.tsx
 index bfa8fda..c04d2c7 100644
 --- a/node_modules/argo-ui/src/context.tsx

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -5,6 +5,7 @@ import type {History} from 'history';
 import * as React from 'react';
 
 import 'argo-ui/src/styles/main.scss';
+import './assets/scss/app-restyle.scss';
 
 import {AppRouter} from './app-router';
 import {ContextApis, Provider} from './shared/context';

--- a/ui/src/assets/scss/_a11y-paint.scss
+++ b/ui/src/assets/scss/_a11y-paint.scss
@@ -1,0 +1,311 @@
+// =============================================================================
+// UI Modernization Restyle — A11Y PAINT LAYER (Bucket-A, paint-only)
+// =============================================================================
+// Loaded LAST from app-restyle.scss so these overrides win the cascade.
+//
+// PAINT-ONLY: this file only ever sets color / background / background-color /
+// border-color / box-shadow / outline / fill / stroke / font-family and
+// animation|transition TIMING. It NEVER changes any box dimension or position
+// (no width/height/padding/margin/top/left/flex/grid/border-width that would
+// move layout). `outline` + `outline-offset` are painted OUTSIDE the box and do
+// not trigger reflow, so the focus rings are geometry-safe.
+//
+// Sass hygiene: @use + sass:color only. No @import, no darken()/lighten().
+// (Keeps the deprecation-warning baseline flat — see argo-workflows-838.)
+//
+// NOTE on markup: this is the PAINT half only. ARIA / markup / role work is
+// deferred to issue argo-workflows-yu9. Nothing here adds or changes DOM.
+//
+// Every token below is referenced as `var(--awf-*, <fallback>)`; the fallback
+// hexes mirror the canonical values in _tokens.scss so this layer is correct
+// even if a token name differs. Spec fallbacks:
+//   muted AA  #556472   link AA   #00808e   focus ring #00808e
+//   warning/suspended dot outline (dark amber) #806100
+//   pending dot outline (darker) #6b5400
+// =============================================================================
+
+@use 'sass:color';
+
+$muted-aa: var(--awf-muted-aa, #556472);
+$link-aa: var(--awf-link-aa, #00808e);
+$focus-ring: var(--awf-focus-ring, #00808e);
+
+$amber-outline: var(--awf-status-warning-outline, #806100);
+$pending-outline: var(--awf-status-pending-outline, #6b5400);
+
+// -----------------------------------------------------------------------------
+// (a) Non-status text — meet AA on body, muted text, and inline links.
+//     Muted text and links are TEXT, so they take the AA-darkened variants.
+//     The brighter #00A2B3 teal is kept for large text / icons / borders.
+// -----------------------------------------------------------------------------
+.muted,
+.text-muted,
+.fa-muted,
+small.muted,
+.columns .muted,
+.row .muted {
+  color: $muted-aa;
+}
+
+a,
+a:link,
+a:visited,
+.link,
+p a,
+li a,
+td a,
+.markdown a {
+  color: $link-aa;
+}
+
+a:hover,
+a:focus,
+.link:hover {
+  color: var(--awf-link-aa-hover, color.adjust(#00808e, $lightness: -8%));
+}
+
+// -----------------------------------------------------------------------------
+// (b) Status TEXT / pill-text -> AA --awf-status-*-text variants.
+//     The DOT / BAR / icon SHAPES keep the saturated canonical argo-ui hues
+//     (we only recolor TEXT here; we do NOT touch DAG / timeline FILL shapes).
+// -----------------------------------------------------------------------------
+
+// workflow-status-badge: the .status / .label text inside the pills (selectors
+// confirmed in ui/src/widgets/workflow-status-badge.scss). The argo-ui rule
+// sets `color: white` on the pill fills; we only override the per-state TEXT.
+// Backgrounds (the saturated fills) are intentionally left untouched.
+.status-badge {
+  .Pending {
+    color: var(--awf-status-pending-text, #566a78);
+  }
+  .Running {
+    color: var(--awf-status-running-text, #0a7299);
+  }
+  .Failed,
+  .Error {
+    color: var(--awf-status-failed-text, #be3d47);
+  }
+  .Succeeded {
+    color: var(--awf-status-succeeded-text, #0a7257);
+  }
+  .Unknown {
+    color: var(--awf-status-unknown-text, #556472);
+  }
+}
+
+// argo-ui status-icon. Its real modifiers (confirmed in
+// node_modules/argo-ui/src/styles/elements/utils.scss: --failed/--success/
+// --waiting/--cancelled/--running/--pending/--init, animated via --spin/
+// --slow-spin) set the icon GLYPH color directly, so the icon IS the shape and
+// MUST keep its saturated canonical hue (do NOT recolor the glyph). We only
+// recolor any ADJACENT status TEXT, never the icon itself.
+.status-icon--pending + span,
+.status-icon--pending ~ .status-text {
+  color: var(--awf-status-pending-text, #566a78);
+}
+.status-icon--running + span,
+.status-icon--running ~ .status-text {
+  color: var(--awf-status-running-text, #0a7299);
+}
+.status-icon--failed + span,
+.status-icon--cancelled + span,
+.status-icon--failed ~ .status-text,
+.status-icon--cancelled ~ .status-text {
+  color: var(--awf-status-failed-text, #be3d47);
+}
+.status-icon--success + span,
+.status-icon--success ~ .status-text {
+  color: var(--awf-status-succeeded-text, #0a7257);
+}
+
+// DAG node label / text in graph-panel, and timeline node text: recolor only
+// the LABEL text; leave the node FILL shapes canonical.
+.graph .node text,
+.graph .node .node-label,
+.workflow-dag .node-label,
+.workflow-timeline .timeline-row .label,
+.workflow-timeline text {
+  fill: var(--awf-node-label-text, #556472);
+  color: var(--awf-node-label-text, #556472);
+}
+
+// Non-text shape outlines so low-contrast status fills clear the 3.0 rule.
+// border-COLOR only (never border-width) + an INSET box-shadow ring, so the box
+// never grows. Adding a real outer outer border here is forbidden (it would
+// reflow). The argo-ui status-ICON is a font glyph with no border box, so the
+// ring is applied to filled DOT/PILL shapes only (the status-badge .Pending
+// pill, plus forward-compatible status-dot--* selectors). The icon glyph keeps
+// its saturated canonical hue untouched.
+.status-badge .Pending,
+.status-dot--warning,
+.status-dot--suspended {
+  border-color: $amber-outline;
+  box-shadow: inset 0 0 0 1px $amber-outline;
+}
+
+.status-dot--pending {
+  border-color: $pending-outline;
+  box-shadow: inset 0 0 0 1px $pending-outline;
+}
+
+// -----------------------------------------------------------------------------
+// (c) Focus visibility. outline + outline-offset paint OUTSIDE the box (no
+//     reflow). Override argo-ui's `outline:none` on interactive elements with
+//     higher specificity so keyboard focus is always visible.
+// -----------------------------------------------------------------------------
+:focus-visible {
+  outline: 2px solid $focus-ring;
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+.argo-button:focus-visible,
+.tabs__tab:focus-visible,
+[role='tab']:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid $focus-ring;
+  outline-offset: 2px;
+}
+
+// -----------------------------------------------------------------------------
+// (d) Reduced motion. Near-instant timing so animation can't induce motion
+//     sickness, and pin the Running spinner / dot to a steady high-visibility
+//     frame so the Running STATE is still conveyed once motion stops.
+// -----------------------------------------------------------------------------
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+
+  // Freeze the running indicator (timing only) and hold its saturated canonical
+  // hue so the Running state stays legible without motion. No transform/geometry
+  // is changed — `animation: none` is a timing/state property.
+  // argo-ui drives the running spin via .status-icon--spin / --slow-spin
+  // (@keyframes spin, see elements/utils.scss). Freeze them (timing only) so
+  // the Running state still reads without motion; the --running modifier
+  // already holds the saturated canonical running hue, so no recolor needed.
+  .fa-spin,
+  .status-icon--spin,
+  .status-icon--slow-spin,
+  .status-dot--running,
+  .spinner,
+  .argo-spinner {
+    animation: none !important;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// (e) High contrast preference. Darken text / muted / link / border and status
+//     pill TEXT to the darkest AA+ variants. Saturated tint FILLS may stay.
+// -----------------------------------------------------------------------------
+@media (prefers-contrast: more) {
+  body,
+  .row,
+  .columns,
+  td,
+  th,
+  p,
+  li {
+    color: var(--awf-text-max, #1c2733);
+  }
+
+  .muted,
+  .text-muted,
+  .fa-muted {
+    color: var(--awf-muted-max, #3c4a57);
+  }
+
+  a,
+  a:link,
+  a:visited,
+  .link {
+    color: var(--awf-link-max, #006570);
+  }
+
+  .row,
+  .columns,
+  table,
+  td,
+  th,
+  .argo-table {
+    border-color: var(--awf-border-max, #8a99a8);
+  }
+
+  .status-badge {
+    .Pending {
+      color: var(--awf-status-pending-text-max, #4a3a00);
+    }
+    .Running {
+      color: var(--awf-status-running-text-max, #0f4d70);
+    }
+    .Failed,
+    .Error {
+      color: var(--awf-status-failed-text-max, #7d1c24);
+    }
+    .Succeeded {
+      color: var(--awf-status-succeeded-text-max, #08502a);
+    }
+    .Unknown {
+      color: var(--awf-status-unknown-text-max, #3c4a57);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// (f) Forced colors (Windows High Contrast). Map surfaces to the system
+//     palette, links to LinkText, focus outline to Highlight, and give status
+//     dots a 1px currentColor border so the SHAPE survives when fills are
+//     stripped by the OS. In forced-colors mode the UA already discards author
+//     colors and box-shadow, so a real 1px border is the ONLY way to preserve
+//     the dot shape — this is the single intentional border, scoped here only.
+// -----------------------------------------------------------------------------
+@media (forced-colors: active) {
+  body,
+  .row,
+  .columns,
+  .top-bar,
+  .nav-bar,
+  .argo-table,
+  .white-box {
+    background-color: Canvas;
+    color: CanvasText;
+  }
+
+  a,
+  a:link,
+  a:visited,
+  .link {
+    color: LinkText;
+  }
+
+  :focus-visible,
+  button:focus-visible,
+  a:focus-visible,
+  input:focus-visible,
+  [role='tab']:focus-visible {
+    outline-color: Highlight;
+  }
+
+  .status-icon,
+  .status-dot,
+  .status-dot--pending,
+  .status-dot--warning,
+  .status-dot--suspended,
+  .status-dot--running {
+    border: 1px solid currentColor;
+    forced-color-adjust: none;
+  }
+}

--- a/ui/src/assets/scss/_font-override.scss
+++ b/ui/src/assets/scss/_font-override.scss
@@ -1,0 +1,30 @@
+// _font-override.scss — UI modernization restyle.
+//
+// Goal: replace argo-ui's default body font ('Heebo', sans-serif) with a
+// native-first stack while retaining Heebo as a fallback.
+//
+// MECHANISM (why this is a plain `body` rule rather than a Sass `!default`
+// override): the app pulls in argo-ui's CSS via a *JavaScript* import
+// (`import 'argo-ui/src/styles/main.scss'` in app.tsx). Under webpack's
+// sass-loader, every JS `.scss` import is its OWN, independent Sass compilation
+// root. argo-ui's main.scss does `@import './config'`, and config.scss declares
+// `$body-font-family: 'Heebo', sans-serif !default;`. A Sass-variable override
+// living in a *different* compilation root (this app-local file) can never reach
+// argo-ui's compile, so assigning `$body-font-family` here would be inert for
+// argo-ui's `body { font-family: $body-font-family }`.
+//
+// What DOES reliably win: a plain `body { font-family }` declaration emitted
+// from a file imported AFTER argo-ui's main.scss. style-loader injects <style>
+// tags in import order, so this rule (same `body` selector, equal specificity,
+// later in the cascade) overrides argo-ui's. This is paint-level only —
+// font-family is an explicitly permitted property and changes no box geometry.
+//
+// The Sass variable below is also declared so that any future app-local partial
+// that `@use`s this file can reference the same stack symbolically. It does NOT
+// affect argo-ui's compile; the winning change is the `body` rule.
+
+$body-font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', 'Heebo', Roboto, sans-serif;
+
+body {
+    font-family: $body-font-family;
+}

--- a/ui/src/assets/scss/_modern-buttons.scss
+++ b/ui/src/assets/scss/_modern-buttons.scss
@@ -1,0 +1,237 @@
+// _modern-buttons.scss — UI restyle (Loop 5): RE-GROUND the button system in
+// REAL Argo CD. The prior loop INVERTED argo-ui's button roles by repainting
+// the neutral-grey workhorse (.argo-button--base) as a SOLID TEAL primary. That
+// moved away from Argo CD, where teal is a SPARING accent (links / focus /
+// outline-hover) and the workhorse for EVERY toolbar action is a NEUTRAL GREY
+// PILL. This file restores Argo CD's actual treatment.
+//
+// ARGO CD GROUND TRUTH (argo-ui src/styles/elements/buttons.scss):
+//   GEOMETRY (all variants): padding 8px 18px; font-size 13px; font-weight 500;
+//     line-height 1.4; border-radius 24px (FULL PILL — a key Argo signature);
+//     transition .2s. (argo-ui's base also UPPERCASEs labels; we de-uppercase to
+//     sentence case below — Argo Workflows' wording reads as shouting in caps.)
+//   .argo-button--base = NEUTRAL GREY workhorse: bg gray-6 #6d7f8b, text gray-1;
+//     hover lightens to gray-5; focus adds a teal-5 ring; disabled gray-4/gray-6.
+//   bare .argo-button = transparent, teal-6 text, grey hover (low-emphasis).
+//   .argo-button--base-o = OUTLINE: transparent, teal-6 text, inset 1px teal-5;
+//     hover FILLS teal-6 with gray-1 text (the ONE place teal becomes a fill).
+//   .argo-button--link = teal-6 text, transparent, grey hover.
+//   .argo-button--special = the rare accent CTA (Get help) — teal accent fill.
+//   .argo-button--radius = teal-5 round FAB (rare, acceptable).
+//
+// CONSISTENCY FIX: there is now ONE coherent system. Both the toolbar primaries
+// (--base) AND the pagination First/Next buttons resolve to the SAME neutral
+// grey pill (pagination-panel.tsx now uses --base), so the old teal-vs-pale-grey
+// clash is gone. --base-o is the single teal-outline secondary.
+//
+// AA NOTE: Argo's literal gray-6/gray-1 pair is only 3.99:1 (< AA 4.5:1). To
+// keep Bucket-A WCAG AA we nudge the resting neutral fill one step darker
+// (--awf-btn-neutral #5a6b78 = 5.30:1) and keep an AA-clean lighter hover
+// (--awf-btn-neutral-hover #637585 = 4.57:1). Visually it is the same neutral
+// slate pill Argo CD uses; only the contrast headroom changed.
+//
+// Loaded AFTER argo-ui via app-restyle.scss so equal-specificity rules win by
+// source order. Sass hygiene: plain CSS + var() tokens; no @import, no
+// darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// SHARED GEOMETRY — restore Argo CD's pill across ALL buttons so there is a
+// single shape language, and set SENTENCE CASE (de-uppercase argo-ui's base).
+// argo-ui base already sets the geometry; we re-assert it on our token scale so
+// every variant below inherits the same shape + casing.
+// -----------------------------------------------------------------------------
+.argo-button {
+    padding: 8px 18px;
+    border-radius: 14px; // Flatter, more rectangular than a full pill (Argo CD), still pill-ish
+    font-size: var(--awf-font-size-sm, 13px);
+    font-weight: var(--awf-weight-medium, 500);
+    line-height: 1.4;
+    letter-spacing: 0;
+    // SENTENCE CASE (Loop 6 fix, restored from Loop 3): argo-ui's base sets
+    // text-transform:uppercase, but Argo Workflows reads as ALL-CAPS shouting
+    // ("SUBMIT NEW WORKFLOW"). De-uppercase here so every button (and the size
+    // variants below, which inherit this) renders in sentence case. The keyword
+    // `none` removes argo-ui's uppercase rather than re-casing the text, so the
+    // label content is untouched — paint-only.
+    text-transform: none;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+
+    // Bare .argo-button (no variant) = Argo CD's low-emphasis control: transparent
+    // with teal-6 text and a quiet grey hover. We use the AA-clean teal link colour
+    // (#00808e, 4.69:1) so the label is readable on the page.
+    &:not(.argo-button--base):not(.argo-button--base-o):not(.argo-button--link):not(.argo-button--rectangle):not(.argo-button--radius):not(.argo-button--radius-2):not(.argo-button--special) {
+        color: var(--awf-link-aa, #00808e);
+        background-color: transparent;
+        box-shadow: none;
+
+        &:not(.disabled):not([disabled]) {
+            &:hover {
+                color: var(--awf-link-aa, #00808e);
+                background-color: var(--awf-canvas, #dee6eb); // grey hover, Argo-like
+            }
+            &:focus {
+                background-color: var(--awf-canvas, #dee6eb);
+            }
+            &:focus-visible {
+                outline: none;
+                box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// PRIMARY / WORKHORSE = .argo-button--base — NEUTRAL GREY PILL (Argo CD).
+// Every toolbar action (and, via markup, the pagination First/Next buttons) uses
+// this. Hover LIGHTENS (Argo's gray-6 -> gray-5 direction); focus adds the teal-5
+// ring as a non-reflowing box-shadow (Argo expresses focus with a teal-5 border).
+// -----------------------------------------------------------------------------
+.argo-button--base {
+    color: var(--awf-btn-on-neutral, #f8fbfb);
+    background-color: var(--awf-btn-neutral, #5a6b78);
+    box-shadow: none;
+
+    &:not(.disabled):not([disabled]) {
+        &:hover {
+            color: var(--awf-btn-on-neutral, #f8fbfb);
+            background-color: var(--awf-btn-neutral-hover, #637585); // lighter, Argo-like
+        }
+        &:active {
+            background-color: var(--awf-btn-neutral-active, #52606e);
+        }
+        &:focus {
+            color: var(--awf-btn-on-neutral, #f8fbfb);
+            background-color: var(--awf-btn-neutral-hover, #637585);
+            // argo-ui adds `border:1px solid teal-5 !important` on focus which
+            // would reflow by 1px. Neutralise it and express the teal-5 ring as a
+            // non-reflowing box-shadow instead (teal only as the focus marker).
+            border: 0 !important;
+            box-shadow: 0 0 0 1px var(--awf-teal-5, #1fbdd0);
+        }
+        &:focus-visible {
+            box-shadow: 0 0 0 1px var(--awf-teal-5, #1fbdd0), var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// OUTLINE / SECONDARY = .argo-button--base-o — the single teal-outline secondary
+// (Argo CD): transparent with teal-6 text and a 1px teal-5 inset border; on hover
+// it FILLS teal-6 with the near-white label (the one place teal becomes a fill).
+// -----------------------------------------------------------------------------
+.argo-button--base-o {
+    color: var(--awf-link-aa, #00808e);
+    background-color: transparent;
+    box-shadow: inset 0 0 0 1px var(--awf-teal-5, #1fbdd0);
+
+    &:not(.disabled):not([disabled]) {
+        &:hover {
+            color: var(--awf-btn-on-neutral, #f8fbfb);
+            // Hover fill uses the AA-clean teal (#008291, white = 4.56:1) rather
+            // than raw teal-6 (#00a2b3, white = 3.08:1) so the label clears AA.
+            background-color: var(--awf-accent-hover, #008291);
+            box-shadow: inset 0 0 0 1px var(--awf-accent-hover, #008291);
+        }
+        &:focus {
+            color: var(--awf-btn-on-neutral, #f8fbfb);
+            background-color: var(--awf-accent-hover, #008291);
+            box-shadow: inset 0 0 0 1px var(--awf-accent-hover, #008291);
+        }
+        &:focus-visible {
+            box-shadow: inset 0 0 0 1px var(--awf-accent-hover, #008291), var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// LINK = .argo-button--link — teal-6 text-only, quiet grey hover (Argo CD).
+// -----------------------------------------------------------------------------
+.argo-button--link {
+    color: var(--awf-link-aa, #00808e);
+    background-color: transparent;
+
+    &:not(.disabled):not([disabled]) {
+        &:hover,
+        &:focus {
+            background-color: var(--awf-canvas, #dee6eb);
+        }
+        &:focus-visible {
+            outline: none;
+            box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SIZE VARIANTS — keep the pill (Argo's --sm is an 18px-radius pill, --short
+// stays pill-rounded via the base 24px). Re-pad on the grid; casing is inherited
+// (sentence case) from the base .argo-button rule above.
+// -----------------------------------------------------------------------------
+.argo-button--sm {
+    min-width: 60px;
+    padding: 0 14px;
+    border-radius: 12px; // Flatter --sm radius (still pill-ish, less bubbly)
+    line-height: 28px;
+    font-size: var(--awf-font-size-label, 12px);
+    font-weight: var(--awf-weight-medium, 500);
+}
+
+.argo-button--short {
+    padding: 5px 14px;
+    // inherits the 24px pill from .argo-button — keeps the single shape language
+}
+
+// -----------------------------------------------------------------------------
+// SPECIAL = .argo-button--special — the floating "Get help" widget. Loop 6
+// accent rationalize (#4): teal is the SPARING interactive accent (links/focus),
+// not a loud standalone fill, so this no longer paints a solid saturated teal
+// pill. It now resolves to the same NEUTRAL ghost as the rest of the system —
+// surface fill, hairline border, teal-6 link text. The widget-specific
+// anchor-vs-`a:link` specificity fix (and the matching ghost treatment scoped at
+// (0,2,0) so it actually wins) lives in _modern-help-button.scss; this base rule
+// is kept consistent for any non-anchor use of --special.
+// -----------------------------------------------------------------------------
+.argo-button--special {
+    color: var(--awf-link-aa, #00808e);
+    background-color: var(--awf-surface, #ffffff);
+    box-shadow: inset 0 0 0 1px var(--awf-hairline, #ccd6dd);
+    &:not(.disabled) {
+        &:hover,
+        &:focus {
+            color: var(--awf-accent-hover, #008291);
+            background-color: var(--awf-ghost-hover, #f0f7f9);
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// DISABLED — faithful to Argo CD: gray-4 fill, gray-6 label, no shadow. (WCAG
+// 1.4.3 exempts inactive controls from the contrast minimum, so reproducing
+// Argo's calm grey-on-grey disabled look is both faithful and compliant.) This
+// replaces the prior solid white-on-dark-grey forced disabled treatment so a
+// disabled pagination button now matches every other disabled button.
+// -----------------------------------------------------------------------------
+.argo-button:disabled,
+.argo-button.disabled {
+    background-color: var(--awf-btn-disabled-bg, #ccd6dd) !important;
+    color: var(--awf-btn-disabled-text, #6d7f8b) !important;
+    box-shadow: none !important;
+    cursor: not-allowed;
+}
+
+// The transparent/text-only variants (bare, link) have no fill when disabled in
+// Argo CD — they just mute the text. Re-assert transparency so they don't pick
+// up the grey disabled fill above and read as a greyed-out label instead.
+.argo-button--link:disabled,
+.argo-button--link.disabled {
+    background-color: transparent !important;
+    color: var(--awf-btn-disabled-text, #6d7f8b) !important;
+}
+
+// -----------------------------------------------------------------------------
+// Round FAB variant stays teal-5 (Argo CD --radius). Modernise only its shadow.
+// -----------------------------------------------------------------------------
+.argo-button--radius {
+    box-shadow: var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1));
+    background-color: var(--awf-teal-5, #1fbdd0);
+}

--- a/ui/src/assets/scss/_modern-cards.scss
+++ b/ui/src/assets/scss/_modern-cards.scss
@@ -1,0 +1,214 @@
+// _modern-cards.scss — UI modernization (Stage B): cohesive cards, panels,
+// elevation, status pills and the de-pilled action toolbar.
+//
+// _modern-surfaces.scss already modernised the argo-ui `.argo-table-list__row`
+// and `.white-box` (8px radius + cohesive soft shadow). This partial covers the
+// surfaces that live in APP-LOCAL scss (filter cards, the workflows action
+// toolbar, status badges) plus the remaining argo-ui elevation surfaces (modal,
+// graph-options, dropdown) so the WHOLE chrome shares ONE shadow scale instead
+// of the old stacked 1/2/3px offset drop shadows.
+//
+// Loaded AFTER argo-ui AND after each component's own app-local scss (the entry
+// imports this restyle bundle last via app.tsx), so equal-specificity rules win
+// by source order. Geometry-within-component only.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// Cohesive elevation: every floating surface gets the same soft shadow + radius
+// family, replacing argo-ui's hard `1px 2px 3px rgba(0,0,0,.1)` offset shadows.
+// -----------------------------------------------------------------------------
+.modal {
+    border-radius: var(--awf-radius-card, 8px);
+    box-shadow: var(--awf-shadow-pop, 0 4px 16px rgba(16, 24, 40, 0.14));
+}
+
+.graph-options-panel {
+    border-radius: var(--awf-radius-card, 8px);
+    box-shadow: var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1));
+}
+
+// -----------------------------------------------------------------------------
+// App-local FILTER CARD — the SINGLE source of truth for the filter-panel
+// surface shared by all four filter sidebars (workflows-list / cron / templates
+// / reports), which ALL render `.wf-filters-container`. Each per-page scss file
+// (workflow-filters / cron-workflow-filters / workflow-template-filters /
+// reports-filters) used to re-declare its own border/radius/shadow/background
+// card-surface block; those duplicated rules are removed there so the surface is
+// defined ONCE here and the four panels can never drift. The hairline BORDER and
+// surface BACKGROUND live with the per-component base; the cohesive elevation +
+// 8px radius + roomy padding are unified here (Loop 9/11). Loaded after the
+// per-page scss (app.tsx imports this restyle bundle last) so it wins by source
+// order; !important keeps it authoritative over any legacy argo-ui card finish.
+// -----------------------------------------------------------------------------
+.wf-filters-container {
+    overflow: visible;
+    position: relative;
+    margin: var(--awf-space-3, 12px) 0;
+    background: var(--awf-surface, #fff);
+    border: 1px solid var(--awf-hairline, #ccd6dd);
+    border-radius: var(--awf-radius-card, 8px) !important;
+    box-shadow: var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1)) !important;
+    // Match the Workflows Summary box padding exactly (16px on all four sides)
+    // so the two left-rail cards read as one consistent system. Previously the
+    // top was 0 and the bottom 12px, leaving the filter card visibly tighter
+    // than the summary box above it.
+    padding: var(--awf-space-4, 16px) !important;
+
+    // ONE unified filter treatment (Loop 11, item 2). All four filter sidebars
+    // (workflows-list / cron / templates / reports) render `.wf-filters-container`
+    // and now share the SAME bordered white card AND the same "Filters" group
+    // header (argo-cd `.filters-group__title`): a centered, muted, hairline-
+    // underlined title that frames the whole panel as one cohesive Argo-CD-style
+    // filters group. The header used to be scoped to the workflows-list panel via
+    // a `--workflows` modifier, which made that one panel read as a designed group
+    // while the other three were a borderless/header-less stack — the exact
+    // inconsistency being unified here. Promoting it to the base selector gives all
+    // four the identical grouped-card treatment. `::before` is a label only; no
+    // markup/logic change.
+    &::before {
+        content: 'Filters';
+        display: block;
+        // Now that the card carries a full 16px top padding (matching the summary
+        // box), the header sits flush at the padding edge — no extra top margin
+        // (which would double the gap). Keep the bottom rhythm to the first field.
+        margin: 0 0 var(--awf-space-3, 12px);
+        padding-bottom: var(--awf-space-2, 8px);
+        border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+        // Group header on the SAME calm treatment as the section labels: 12px,
+        // semibold, sentence case, NO tracking (the old uppercase + 0.04em was
+        // the "stupidly spaced out" cheap look). Left-aligned to the one shared
+        // left edge so nothing is centred/indented differently.
+        text-align: left;
+        font-size: var(--awf-font-size-label, 12px);
+        font-weight: var(--awf-weight-semibold, 600);
+        letter-spacing: normal;
+        text-transform: none;
+        color: var(--awf-heading, #363c4a);
+    }
+
+    // The FIRST field label in every panel should sit snug under the shared
+    // "Filters" header rather than carrying its own top margin (the vertically
+    // stacked panels give each `p` a 1em top margin; the workflows panel lays its
+    // groups out horizontally). Trim the first label's top margin in all four so
+    // the header-to-first-field rhythm is identical across pages.
+    .row > .columns:first-child .wf-filters-container__title,
+    .row > .columns:first-child p:first-child {
+        margin-top: var(--awf-space-2, 8px);
+    }
+
+    // Field-label TYPOGRAPHY is owned by _modern-controls.scss (Loop 5 R3), which
+    // re-grounds these labels on Argo CD's pervasive UPPERCASE muted-grey eyebrow
+    // (matching the R2 logs toolbar) for ONE consistent field-label treatment
+    // app-wide. Only the card SURFACE (radius / shadow / padding above) is owned
+    // here. Calm tracking is kept as a harmless, non-!important default that
+    // _modern-controls re-asserts at the same value.
+    p {
+        letter-spacing: normal;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// List rows: complement _modern-surfaces (radius/shadow/hover) with comfortable
+// VERTICAL rhythm. argo-ui rows are a single 52px line; give the clickable list
+// a touch more inter-row gap so cards read as discrete, tappable surfaces.
+// (Color/selected/hover already handled in _modern-surfaces — not repeated.)
+// -----------------------------------------------------------------------------
+.argo-table-list--clickable .argo-table-list__row {
+    cursor: pointer;
+    transition: background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+// -----------------------------------------------------------------------------
+// WORKFLOWS ACTION TOOLBAR: argo-ui-adjacent app toolbar ships gray, 3px-radius,
+// pill-ish action chips on a flat gray band. Modernise to a crisp surface bar
+// with de-pilled 6px action buttons that share the button radius family. Colours
+// (suspend/resume/delete) are preserved — only geometry + the band finish move.
+// -----------------------------------------------------------------------------
+.workflows-toolbar {
+    background: var(--awf-surface, #fff);
+    box-shadow: 0 1px 0 0 var(--awf-hairline, #ccd6dd);
+    padding: var(--awf-space-2, 8px) var(--awf-space-5, 20px);
+
+    &__actions--action {
+        border-radius: var(--awf-radius-control, 6px);
+        padding: var(--awf-space-1, 4px) var(--awf-space-3, 12px);
+        font-weight: var(--awf-weight-medium, 500);
+        transition: background-color 0.15s ease, box-shadow 0.15s ease;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// STATUS BADGE widget: convert the flat full-colour blocks into rounded
+// tinted-alpha pills with AA status text and a canonical-hue leading dot. The
+// fixed 80/120px column widths are preserved (no overflow); only the finish and
+// the inner radius change. The name `.label` stays a calm neutral chip.
+// -----------------------------------------------------------------------------
+.status-badge {
+    height: auto;
+
+    .label,
+    .status {
+        // Keep the original 80/120px as a FLOOR (min-width) rather than a hard
+        // cap so the dot + roomier padding can never clip the status word. The
+        // columnar rhythm is preserved; long content expands instead of cutting.
+        width: auto;
+        min-width: 80px;
+        padding: var(--awf-space-1, 4px) var(--awf-space-2, 8px);
+        text-transform: none;
+        font-weight: var(--awf-weight-medium, 500);
+        line-height: 1.4;
+        overflow: visible;
+    }
+
+    // Neutral name chip on the left, rounded on its leading edge.
+    .label {
+        min-width: 120px;
+        background-color: var(--awf-canvas, #dee6eb);
+        color: var(--awf-heading, #363c4a);
+        border-radius: var(--awf-radius-control, 6px) 0 0 var(--awf-radius-control, 6px);
+    }
+
+    // Status chip on the right, rounded on its trailing edge. Default neutral.
+    .status {
+        background-color: var(--awf-canvas, #dee6eb);
+        color: var(--awf-muted-aa, #556472);
+        border-radius: 0 var(--awf-radius-control, 6px) var(--awf-radius-control, 6px) 0;
+
+        // Canonical-hue leading dot before the status word.
+        &::before {
+            content: '';
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            margin-right: var(--awf-space-1, 4px);
+            border-radius: var(--awf-radius-pill, 999px);
+            background-color: currentColor;
+            vertical-align: middle;
+        }
+    }
+
+    // Per-phase tinted-alpha background + AA text. Dot inherits currentColor, so
+    // the text colour IS the canonical hue (AA verified in _tokens.scss).
+    .status.Unknown {
+        background-color: rgba(109, 127, 139, 0.14);
+        color: var(--awf-status-pending-text, #566a78);
+    }
+    .status.Pending {
+        background-color: rgba(244, 192, 48, 0.18);
+        color: var(--awf-status-warning-text, #806100);
+    }
+    .status.Running {
+        background-color: rgba(13, 173, 234, 0.16);
+        color: var(--awf-status-running-text, #0a7299);
+    }
+    .status.Failed,
+    .status.Error {
+        background-color: rgba(233, 109, 118, 0.18);
+        color: var(--awf-status-failed-text, #be3d47);
+    }
+    .status.Succeeded {
+        background-color: rgba(24, 190, 148, 0.16);
+        color: var(--awf-status-succeeded-text, #0a7257);
+    }
+}

--- a/ui/src/assets/scss/_modern-chrome.scss
+++ b/ui/src/assets/scss/_modern-chrome.scss
@@ -1,0 +1,157 @@
+// _modern-chrome.scss — UI modernization (Stage B): crisp flat nav + top bar.
+//
+// The nav is already flat #1A1C22 from Loop 1 (argo-ui patch). This partial
+// refines the CHROME finish via cascade only: a crisper top-bar hairline + band,
+// modern breadcrumb hover chips, a calmer skewed separator, and a slightly more
+// generous nav active/hover rhythm — all paint/geometry-within-component, none
+// of it touching the JS-shared $nav-width / $top-bar-height dimensions (those
+// are left at 60px / 50px so the page frame + the app toolbar's hardcoded
+// `top: calc(50px * 2)` stay perfectly aligned).
+//
+// Loaded AFTER argo-ui, _overrides-topbar (filter dot), _overrides-chrome
+// (sliding-panel footer hairline) and _modern-type (title de-uppercase), so
+// these win by source order without raising specificity.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// TOP BAR: keep it white + flat, but make the bottom edge a crisp single
+// hairline in the palette tone and add comfortable side gutters so the title /
+// breadcrumbs / actions sit on the 8px grid instead of a tight 20px.
+// (Height stays $top-bar-height = 50px — shared with the page frame + toolbar.)
+// -----------------------------------------------------------------------------
+.top-bar {
+    background: var(--awf-surface, #fff);
+    border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+
+    &__left-side {
+        padding-left: var(--awf-space-6, 24px);
+    }
+
+    &__right-side {
+        padding-right: var(--awf-space-6, 24px);
+    }
+}
+
+// Breadcrumb links: modern, calm hover chip (was a hard gray-2 fill) with a
+// control-radius corner and the AA link tone.
+.top-bar__breadcrumbs a {
+    color: var(--awf-link-aa, #00808e);
+    border-radius: var(--awf-radius-control, 6px);
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover {
+        background-color: var(--awf-ghost-hover, #f0f7f9);
+        color: var(--awf-link-aa, #00808e);
+    }
+}
+
+// Skewed separator: soften the hard rotated rule into a calm vertical hairline
+// in the palette tone (keep the subtle skew — it is part of the brand rhythm).
+.top-bar__sep {
+    border-left-color: var(--awf-hairline, #ccd6dd);
+    height: 20px;
+}
+
+// Action menu: a touch more breathing room between top-bar action icons.
+.top-bar__action-menu {
+    gap: var(--awf-space-1, 4px);
+}
+
+// -----------------------------------------------------------------------------
+// CHROME BAND UNIFICATION: the fixed workflows action toolbar sits directly
+// under the top bar (it hardcodes `top: calc(50px * 2)` in argo-ui-land — DO
+// NOT touch that). It already shares the white surface + bottom hairline (see
+// _modern-cards.scss). Here we only align its LEFT gutter to the top-bar gutter
+// (24px) so the two bands read as one continuous chrome band with a common left
+// content edge, instead of the toolbar's content starting 4px in from the bar
+// above it. Right gutter is left at the toolbar's own value (it holds the count
+// + actions which align right). Paint/gutter only — no height/position change.
+// -----------------------------------------------------------------------------
+.workflows-toolbar {
+    padding-left: var(--awf-space-6, 24px);
+}
+
+// -----------------------------------------------------------------------------
+// NAV RAIL WIDTH LOCKSTEP. The rail is reworked in the argo-ui nav-bar patch into
+// a thin navy ICON rail (~60px, icon-only with hover tooltips). argo-ui's page
+// frame derives `.page` padding-left, `.page__top-bar` left and the app's
+// `.workflows-toolbar` width from the compiled `$nav-width: 60px` literal, so we
+// re-point all three at the SAME --awf-nav-width token the patch uses, keeping
+// the content frame perfectly aligned to the rail with one source of truth.
+// The nav-bar.scss patch owns the rail's own colour/layout/active-state; here we
+// only keep the rest of the page aligned to it (no per-item paint duplicated).
+// The --awf-nav-width token is declared in _tokens.scss.
+// -----------------------------------------------------------------------------
+.page {
+    padding-left: var(--awf-nav-width, 60px);
+}
+
+// -----------------------------------------------------------------------------
+// NAV RAIL FULL-HEIGHT GUARD. The navy rail is `position:fixed; top:0; bottom:0`
+// in the nav-bar patch, so it spans the viewport. RE-ASSERT that here app-locally
+// (top/bottom:0 + min-height:100vh) so the rail can never be left short with a
+// white strip below it if a shared-layout edit elsewhere ever perturbs its box —
+// this is the single source of truth for the rail spanning the FULL viewport
+// height. Paint/geometry of the rail's OWN box only; no behaviour change.
+.nav-bar {
+    top: 0;
+    bottom: 0;
+    min-height: 100vh;
+}
+
+.page__top-bar {
+    left: var(--awf-nav-width, 60px);
+}
+
+// The workflows action toolbar is `position:fixed; right:0` with a hardcoded
+// `width: calc(100% - 60px)`; re-point that 60px at the rail token so it spans
+// exactly the content area beside the wider rail (vertical `top` is untouched).
+.workflows-toolbar {
+    width: calc(100% - var(--awf-nav-width, 60px));
+}
+
+// -----------------------------------------------------------------------------
+// NAV VERSION STRING. Argo CD shows a muted version line under the logo; we
+// RESTORE that here (a prior loop hid it with display:none after an earlier loop
+// had let it truncate to "lates..."). The argo-ui nav-bar patch now styles it to
+// WRAP (white-space:normal + overflow-wrap:anywhere) onto two or three short
+// centered lines that fit the 60px rail with no clipping, and carries the full
+// string in a native `title` tooltip. We re-assert the same legible, wrapping
+// treatment app-locally so it wins by source order even if the patch's nowrap
+// past were to linger, and so the version is never clipped in the thin rail.
+//
+// Contrast: the muted slate is lifted to #9aa6ad on the #0f2733 navy rail
+// (~5.9:1) so the 9px text clears WCAG AA for small text.
+// -----------------------------------------------------------------------------
+// Selector carries the parent `.nav-bar__logo` so it outranks the argo-ui
+// nav-bar.scss `.nav-bar__version` rule (which still ships overflow-wrap:anywhere
+// + 9px) regardless of bundle source order — otherwise the patch's "anywhere"
+// wins and the string breaks mid-token again.
+.nav-bar__logo .nav-bar__version {
+    display: block;
+    // The logo block pads 12px each side, leaving the version only ~28px — too
+    // narrow, so even a separator-delimited token like "ddefaca" overflowed and
+    // was chopped mid-word. Pull the version out past that horizontal padding
+    // with matched negative margins so it can use the FULL ~58px rail width, and
+    // keep just 1px side padding. With the wider box the build token
+    // "latest+ddefaca" fits one line and the string wraps once at the '.' into a
+    // tidy "latest+ddefaca" / ".dirty" — no mid-word split.
+    margin: 0 -12px;
+    width: 60px; // span the FULL rail (counteracts the logo's 12px side padding)
+    max-width: 60px;
+    padding: 2px 1px 6px;
+    box-sizing: border-box;
+    font-size: 8px; // each separator token fits the rail width at 8px
+    line-height: 1.3;
+    color: #9aa6ad; // muted slate, AA on the navy rail
+    text-align: center;
+    white-space: normal; // override any nowrap so the string can WRAP
+    // word-break:normal keeps tokens whole (no "ddef/aca" chop); break-word is
+    // only the last resort for a single token wider than the now-full-width box.
+    // The native title tooltip still carries the full string.
+    word-break: normal;
+    overflow-wrap: break-word;
+    text-overflow: clip; // cancel the ellipsis clamp
+    overflow: visible;
+}

--- a/ui/src/assets/scss/_modern-controls.scss
+++ b/ui/src/assets/scss/_modern-controls.scss
@@ -1,0 +1,347 @@
+// _modern-controls.scss — UI restyle (Loop 5, Stage R3): CONTROL CONSISTENCY +
+// SPACING POLISH across the whole app, so every filter / toolbar / dropdown
+// reads as ONE coherent Argo-CD control system.
+//
+// WHY THIS PARTIAL EXISTS (the R3 gap R1/R2 left):
+//   R1 unified the BUTTON system (neutral-grey pill everywhere). R2 rebuilt the
+//   LOGS toolbar on Argo CD's rhythm, where each field carries a small UPPERCASE
+//   muted-grey eyebrow label (Argo CD's `.argo-form-row label` idiom) and every
+//   control sits on one shared height. But the four FILTER panels
+//   (.wf-filters-container: workflows / workflow-template / cron / reports) were
+//   never re-grounded — their field labels (`.wf-filters-container__title`) are
+//   15px and were even pushed to SENTENCE case by _modern-cards.scss:45-49, which
+//   directly contradicts (a) Argo CD's ground truth ("UPPERCASE is pervasive and
+//   load-bearing — form labels are all uppercase 12-13px") and (b) R2's own logs
+//   eyebrow labels. So the app had TWO different field-label treatments for the
+//   same kind of control — exactly the inconsistency R3 must resolve.
+//
+// WHAT THIS DOES (paint/geometry only, no markup, no logic):
+//   1. FIELD LABELS: make every filter-panel field label the SAME small UPPERCASE
+//      muted-grey eyebrow R2 uses in the logs toolbar (12px / 500 / 0.04em /
+//      uppercase / --awf-muted). This wins over the sentence-case rule in
+//      _modern-cards.scss by SOURCE ORDER (loaded after it).
+//   2. CONTROL HEIGHTS: pin the filter inputs / autocompletes / selects /
+//      tags-input to the SAME 34px control height the logs toolbar uses, so a row
+//      of mixed controls (text field, dropdown, date picker, tag box) sits on one
+//      clean baseline instead of stair-stepping.
+//   3. SPACING: give each field a consistent 8px-grid stack (label -> 4px -> control,
+//      field -> 16px -> next field) so the panels share the logs toolbar's density.
+//   4. TOP-BAR FILTER DROPDOWN MENUS: align the `.top-bar__filter-item` rows to the
+//      same control rhythm + hover wash so the Name-filter / phase dropdowns match.
+//
+// Loaded AFTER _modern-cards, _modern-inputs and _modern-logs (see app-restyle),
+// so equal-specificity rules win by source order without raising specificity.
+// Sass hygiene: plain CSS + var() tokens; no @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// (1) FILTER-PANEL FIELD LABELS = the shared Argo-CD eyebrow.
+//     `.wf-filters-container__title` is the label `<p>` above every filter
+//     control. Re-ground it to the SAME idiom as the logs toolbar's
+//     `.log-menu__label` (UPPERCASE, 12px, 500, muted grey, calm tracking). This
+//     overrides _modern-cards.scss's sentence-case `p { text-transform:none }`
+//     by source order so there is ONE field-label treatment app-wide.
+//
+//     The duplicated `.wf-filters-container .wf-filters-container__title` reach
+//     matches the specificity of the `_modern-cards` `.wf-filters-container p`
+//     rule (0,2,0) so this reliably wins on top of source order, without
+//     resorting to `!important`.
+// -----------------------------------------------------------------------------
+// CRAFT FIX (workflows filter sidebar): the panel previously mixed random font
+// sizes, uppercase + 0.04em tracking (the "stupidly spaced out" eyebrows),
+// stray Foundation column gutters (the "random indentations"), and broken
+// vertical rhythm (labels crashing into the field above). The block below
+// re-grounds the WHOLE sidebar on ONE strict, minimal type scale and one
+// consistent left edge + 8px rhythm, while keeping every control working and
+// the teal focus ring intact.
+//
+// STRICT TYPE SCALE (every sidebar text element maps to exactly one of these):
+//   • Section labels  -> 12px / 600 / letter-spacing normal / sentence case
+//   • Field/control   -> 14px (inputs, selects, tags, date pickers, phase labels)
+//   • Phases count    -> 12px (the right-aligned count badge)
+//   • Summary numbers -> owned by workflows-summary-container.scss
+// All sidebar text inherits the shared body font stack (no divergent family).
+
+.wf-filters-container .wf-filters-container__title {
+    // Section label = ONE size, ONE weight, calm (no tracking), sentence case.
+    margin: var(--awf-space-3, 12px) 0 var(--awf-space-1, 4px);
+    padding: 0;
+    font-family: inherit;
+    font-size: var(--awf-font-size-label, 12px);
+    font-weight: var(--awf-weight-semibold, 600);
+    line-height: 1.2;
+    letter-spacing: normal;
+    text-transform: none;
+    color: var(--awf-muted-aa, #556472);
+}
+
+// The DropDown anchor used for the "Name Contains / Prefix / …" selector is ALSO
+// a `.wf-filters-container__title` but it is interactive (it carries a caret and
+// opens a menu). Keep the eyebrow look but mark it as clickable so it reads as a
+// control, not a static label. It must still carry the SAME 16px top / 4px bottom
+// section-header rhythm as every other eyebrow (the base rule already sets that;
+// we previously zeroed the top margin here, which made this one section sit
+// cramped against the field above it — the panel's uneven vertical rhythm). Keep
+// the shared rhythm and only add the clickable affordance + caret tone.
+.wf-filters-container .top-bar__filter {
+    // The caret used to float at the far end of the full-width eyebrow, reading as
+    // if it belonged to the plain TEXT BOX rendered directly below it (so the box
+    // looked like a misleading dropdown). Shrink the clickable anchor to hug only
+    // its own text + caret (inline-flex, width auto) so the "Name Contains ⌄" unit
+    // reads as one self-contained mode selector that is clearly the LABEL's
+    // affordance, not the box's. Behaviour untouched — still opens the same menu.
+    display: inline-flex;
+
+    .wf-filters-container__title {
+        display: inline-flex;
+        align-items: center;
+        width: auto;
+        max-width: none;
+        cursor: pointer;
+        transition: color 0.15s ease;
+
+        i {
+            color: var(--awf-muted, #6d7f8b);
+            margin-left: var(--awf-space-1, 4px);
+            transition: color 0.15s ease;
+        }
+
+        &:hover {
+            color: var(--awf-text, #495763);
+
+            i {
+                color: var(--awf-text, #495763);
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// (2) FILTER CONTROL HEIGHTS — one shared 34px baseline (matches the logs
+//     toolbar). The filter inputs are:
+//       • InputFilter / NamespaceFilter -> an Autocomplete `.select` wrapping an
+//         `<input className='argo-field'>`  (boxed by _modern-inputs already)
+//       • DataLoaderDropdown            -> an `.argo-select`
+//       • DatePicker                    -> `<input class='argo-field argo-textarea'>`
+//       • TagsInput                     -> `.tags-input` box
+//     _modern-inputs gives the text fields/selects their box + teal focus ring;
+//     here we only NORMALISE their HEIGHT (and the autocomplete wrapper width) so
+//     they line up. Heights are set with box-sizing:border-box so the existing
+//     1px border + padding are absorbed, not added on top.
+// -----------------------------------------------------------------------------
+.wf-filters-container {
+    // (A0) Foundation `.row` carries a NEGATIVE side margin (-15px) that pulls
+    //      its content OUT past the card's 16px padding, so every filter row —
+    //      and notably the Phases list's right-aligned counts — sat hard against
+    //      the card border (overflowing the intended inner gutter). Zero that
+    //      negative margin so the whole filter content respects the card padding
+    //      and nothing touches the right edge. Width auto keeps it full-bleed
+    //      within the padded content box.
+    .row {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    // (A) ONE consistent left edge. The workflows panel lays its filter blocks
+    //     out as Foundation `.columns`, which inject a 10px small-gutter
+    //     padding-left/right — the "random indentations that take up unnecessary
+    //     space". Zero the gutter so every label + control aligns to the SAME
+    //     left edge as the card padding and uses the full card width. The blocks
+    //     stack on a clean 8px rhythm with a clear gap between each filter.
+    .row > .columns {
+        padding-left: 0;
+        padding-right: 0;
+        margin-bottom: var(--awf-space-4, 16px);
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    // (B) ALL sidebar text uses the shared body font stack (no divergent family)
+    //     and the body 14px control size — covering inputs, selects, tags,
+    //     date-picker fields and the phase rows.
+    .argo-field,
+    .argo-textarea,
+    .argo-select,
+    .select__value,
+    .tags-input,
+    .tags-input__input,
+    .checkbox-filter,
+    .checkbox-filter label {
+        font-family: inherit;
+        font-size: var(--awf-font-size-body, 14px);
+    }
+
+    // The autocomplete wrapper should fill the column so its boxed input is full
+    // width like every other control (argo-ui leaves `.select` shrink-to-fit).
+    .input-filter .select,
+    .input-filter .argo-field {
+        width: 100%;
+    }
+
+    // Shared control height for the boxed text / select controls.
+    .argo-field,
+    .argo-textarea,
+    .argo-select {
+        box-sizing: border-box;
+        height: 34px;
+    }
+
+    // The tags box is a multi-line container; give it the same MINIMUM height and
+    // vertical centring so an empty tag box matches the single-line controls but
+    // can still grow when tags wrap.
+    .tags-input {
+        box-sizing: border-box;
+        min-height: 34px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        border-radius: var(--awf-radius-control, 6px);
+    }
+
+    // (2b) The Workflow-Template / Cron-Workflow filters render an argo-ui custom
+    //      `Select` (DataLoaderDropdown), NOT an `.argo-select`. Out of the box it
+    //      paints a BORDERLESS bottom-line control at 15px with ~8px asymmetric
+    //      padding — so those two fields read completely differently from the
+    //      boxed `.argo-field` text inputs above/below them (the single biggest
+    //      "random sizes / no consistent styling" break in this panel). Re-box the
+    //      `.select__value` so it matches every other control: same 34px height,
+    //      1px hairline box, 6px radius, 14px body text, full width, calm padding,
+    //      and the shared teal focus ring on keyboard focus. Display-only; the
+    //      Select's open/close behaviour and the caret are untouched.
+    .select {
+        width: 100%;
+
+        // Hidden focus-receiver input is fine; the visible value box is what we
+        // restyle into a real boxed control.
+        &__value {
+            box-sizing: border-box;
+            display: flex;
+            align-items: center;
+            height: 34px;
+            padding: 0 28px 0 10px; // room for the caret on the right
+            font-size: var(--awf-font-size-body, 14px);
+            line-height: 1.2;
+            color: var(--awf-text, #495763);
+            background-color: var(--awf-surface, #fff);
+            border: 1px solid var(--awf-hairline, #ccd6dd);
+            border-radius: var(--awf-radius-control, 6px);
+            transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        // Keyboard focus lands on the hidden `.select__focus-receiver`; mirror the
+        // shared teal ring onto the visible value box so focus is honest + AA.
+        &__focus-receiver:focus + .select__value {
+            outline: 0;
+            border-color: var(--awf-accent, #00a2b3);
+            box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+        }
+
+        // Caret. argo-ui positions `.select__value-arrow` absolutely at `right: 0`
+        // of the value box, but the `argo-icon-expand-arrow` glyph carries a chunk
+        // of trailing side-bearing inside its advance box, so the VISIBLE chevron
+        // floated ~10px clear of the right border and read as detached / shoved
+        // left. Pin the arrow as a fixed-size, right-aligned glyph box sat at a
+        // small intentional inset from the inner edge, and zero the icon-font's
+        // line-box so the glyph itself (not its advance box) lands neatly at the
+        // right inside edge like a standard select caret. Muted to match the
+        // chrome's chevron tone. Position/paint only — open/close behaviour
+        // untouched, and the value box keeps its 28px right padding so text never
+        // runs under the caret.
+        &__value-arrow {
+            right: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: flex-end;
+            color: var(--awf-muted, #6d7f8b);
+
+            i {
+                display: block;
+                font-size: 14px;
+                line-height: 1;
+            }
+        }
+    }
+
+    // The date-picker row keeps its inline clear-affordance to the right of the
+    // field; align them on one row with a small gap instead of space-between so
+    // the clear icon sits next to the field, not floated to the panel edge.
+    &__content {
+        justify-content: flex-start;
+        gap: var(--awf-space-2, 8px);
+
+        // React-datepicker wraps the input in its own div; let it fill the row so
+        // the field matches the width of the other controls.
+        .react-datepicker-wrapper {
+            flex: 1;
+        }
+
+        a {
+            display: inline-flex;
+            align-items: center;
+            color: var(--awf-muted, #6d7f8b);
+            cursor: pointer;
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// (3) TOP-BAR FILTER DROPDOWN MENUS. The Name-filter and other `.top-bar__filter`
+//     dropdowns render their options as `.top-bar__filter-item` rows inside the
+//     popover. Give the items consistent padding, the muted body tone, and the
+//     same quiet hover wash the rest of the chrome uses, so the menu rhythm
+//     matches the buttons + fields rather than the raw argo-ui list defaults.
+//     (The popover surface itself — radius + soft pop shadow — is already aligned
+//     in _modern-surfaces `.argo-dropdown__content`.)
+// -----------------------------------------------------------------------------
+.top-bar__filter-item {
+    color: var(--awf-text, #495763);
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover {
+        background-color: var(--awf-ghost-hover, #f0f7f9);
+    }
+
+    // The section-title rows in these menus (e.g. the filter group heading) read
+    // as the same uppercase muted eyebrow used everywhere else.
+    &.title {
+        color: var(--awf-muted, #6d7f8b);
+        text-transform: uppercase;
+        font-size: var(--awf-font-size-label, 12px);
+        font-weight: var(--awf-weight-medium, 500);
+        letter-spacing: var(--awf-tracking-label, 0.04em);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// (4) PHASES FILTER ROWS. The workflows filter sidebar's Phases list renders
+//     [checkbox][colored dot][label][count] rows via the CheckboxFilter component
+//     (`.checkbox-filter__label`). The component scss ellipsis-clipped the longest
+//     phase label ("Succeeded") even though the filter card has room. The card is
+//     wide enough for every phase name (Pending / Running / Succeeded / Failed /
+//     Error) to sit on one line beside its count, so let the label take the room
+//     it needs instead of clamping it.
+//
+//     We keep the row's [checkbox][dot][label][count] layout untouched and only
+//     relax the label so it no longer truncates: the label flexes to fill the
+//     space left by the (auto-margin, right-aligned) count, wraps cleanly if a
+//     future label were ever longer than the rail, and never shows an ellipsis.
+//     The .row's own `nowrap` keeps the dot + count pinned on the same line.
+//     (App-local + a tick of extra specificity so it wins over the component
+//     scss regardless of bundle order.)
+// -----------------------------------------------------------------------------
+.checkbox-filter li > .row .checkbox-filter__label {
+    overflow: visible;
+
+    label {
+        // Size the label to its content and never let it shrink below it: with
+        // flex-shrink 0 (and NO min-width:0 clamp) the longest phase name
+        // ("Succeeded", ~75px) keeps its full width. The card row has slack
+        // (wrap 156px vs ~145px of content) so checkbox + dot + label + the
+        // right-aligned count all fit on one line — no ellipsis, no clip.
+        flex: 0 0 auto;
+        overflow: visible;
+        text-overflow: clip; // belt-and-braces: never ellipsize "Succeeded" et al.
+        white-space: nowrap;
+    }
+}

--- a/ui/src/assets/scss/_modern-help-button.scss
+++ b/ui/src/assets/scss/_modern-help-button.scss
@@ -1,0 +1,65 @@
+// _modern-help-button.scss — CALM the floating bottom-right "Get help" widget.
+//
+// THE WIDGET (ChatButton) renders as
+//   <a class="argo-button argo-button--special chat-button"> <i…/> Get help</a>
+// i.e. an ANCHOR with an href. The a11y-paint layer (loaded LAST) sets
+//   a, a:link, a:visited { color: var(--awf-link-aa) }   // teal #00808e
+// and `a:link` carries specificity (0,1,1) — which BEATS argo-ui's and the
+// restyle's `.argo-button--special { color:… }` at (0,1,0). So any colour we
+// want on the label MUST be scoped at >= (0,1,1). We target the widget by its
+// stable hook class `.chat-button` COMBINED WITH `.argo-button--special`,
+// giving (0,2,0) which cleanly beats `a:link` (0,1,1).
+//
+// LOOP 6 ACCENT RATIONALIZE (#4): the prior treatment was a SOLID saturated
+// teal pill (#008291 fill, white label) floating on every page — the single
+// most saturated element on screen, fighting the brand orange (logo) and the
+// green status pills. Teal is meant to be the SPARING interactive accent
+// (links / focus), not a billboard. So we drop it onto the NEUTRAL button
+// system: a quiet white/surface ghost pill with a hairline border and the
+// AA-clean teal-6 link colour for the label + icon (teal stays in its
+// interactive lane as text, not as a loud fill). The pill still reads as a
+// clear, tappable affordance, just calm.
+//
+// AA: teal-6 link #00808e on the white/surface fill = 4.69:1 (>= 4.5:1, AA for
+// normal text). Hover deepens the text to the darker accent and adds the faint
+// teal wash background (still teal-6 text on a near-white wash, AA-clean).
+//
+// Loaded AFTER a11y-paint in app-restyle so this scoped rule wins by source
+// order too (belt-and-suspenders alongside the specificity win).
+//
+// Sass hygiene: plain CSS + var() tokens only. No @import, no darken()/lighten().
+
+.chat-button.argo-button--special {
+    // Neutral ghost pill: white/surface fill, hairline border, teal-6 link text.
+    // (0,2,0) beats the a11y-paint `a:link` teal at (0,1,1), so the label colour
+    // we set here actually applies.
+    color: var(--awf-link-aa, #00808e);
+    background-color: var(--awf-surface, #ffffff);
+    box-shadow: inset 0 0 0 1px var(--awf-hairline, #ccd6dd), var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1));
+
+    i {
+        // The leading comment glyph shares the calm teal-6 label colour.
+        color: var(--awf-link-aa, #00808e);
+    }
+
+    &:not(.disabled) {
+        &:hover,
+        &:focus {
+            // Stay in the neutral system on interaction: a faint teal wash with
+            // the deeper accent text (teal-6 text on the near-white wash is
+            // AA-clean), instead of flooding to a saturated teal fill.
+            color: var(--awf-accent-hover, #008291);
+            background-color: var(--awf-ghost-hover, #f0f7f9);
+            box-shadow: inset 0 0 0 1px var(--awf-hairline, #ccd6dd), var(--awf-shadow-card-hover, 0 2px 4px rgba(16, 24, 40, 0.08), 0 4px 10px rgba(16, 24, 40, 0.1));
+
+            i {
+                color: var(--awf-accent-hover, #008291);
+            }
+        }
+
+        &:focus-visible {
+            outline: none;
+            box-shadow: inset 0 0 0 1px var(--awf-teal-5, #1fbdd0), var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+        }
+    }
+}

--- a/ui/src/assets/scss/_modern-inputs.scss
+++ b/ui/src/assets/scss/_modern-inputs.scss
@@ -1,0 +1,82 @@
+// _modern-inputs.scss — UI modernization: boxed inputs with a teal focus ring.
+//
+// argo-ui fields are UNDERLINE-only (`border:0; border-bottom:2px solid border`).
+// Underline fields read as an old Material admin. We convert the text field,
+// textarea and select into real 6px-radius boxes with a calm hairline border
+// and a non-reflowing teal focus ring (box-shadow, not outline, so it paints
+// over the rounded corner cleanly and never shifts layout).
+//
+// LABEL MATH NOTE: the floating placeholder lives in `.argo-field-container`
+// (padding-top:12px) and animates from translateY(6px) to translateY(-25px),
+// i.e. it floats ABOVE the field. Boxing the field adds top padding/border but
+// the floated label sits outside/above the box, so -25px still clears it.
+// Verified visually after build.
+//
+// Loaded AFTER argo-ui and after _overrides-chrome (which only set the field
+// border COLOUR), so these win by source order.
+
+// -----------------------------------------------------------------------------
+// Text field + textarea -> boxed.
+// -----------------------------------------------------------------------------
+.argo-field,
+.argo-textarea {
+    padding: 8px 10px;
+    font-size: var(--awf-font-size-body, 14px);
+    background-color: var(--awf-surface, #fff);
+    // Replace the bottom-only 2px rule with a full 1px box + radius.
+    border: 1px solid var(--awf-hairline, #ccd6dd);
+    border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+    border-radius: var(--awf-radius-control, 6px);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus {
+        outline: 0;
+        border-color: var(--awf-accent, #00a2b3);
+        box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+    }
+}
+
+// The boxed action-field variant: just align radius + ring (already bordered).
+.argo-field__with-action-btn {
+    border: 1px solid var(--awf-hairline, #ccd6dd);
+    border-radius: var(--awf-radius-control, 6px);
+
+    &:focus {
+        border-color: var(--awf-accent, #00a2b3);
+        box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Select -> boxed. argo-ui forces `box-shadow:none !important` and a 40px height
+// with a bottom rule; rebuild as a box. Match the !important on focus shadow so
+// the ring is not stripped.
+// -----------------------------------------------------------------------------
+.argo-select {
+    height: 38px;
+    padding: 0 10px;
+    font-size: var(--awf-font-size-body, 14px);
+    background-color: var(--awf-surface, #fff);
+    border: 1px solid var(--awf-hairline, #ccd6dd);
+    border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+    border-radius: var(--awf-radius-control, 6px);
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus {
+        border: 1px solid var(--awf-accent, #00a2b3);
+        box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28)) !important;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Checkbox: nudge the corner to match the control radius family (was 3px), and
+// use the accent token for the checked fill.
+// -----------------------------------------------------------------------------
+.argo-checkbox input + span {
+    border-radius: 4px;
+    border-color: var(--awf-muted-aa, #556472);
+}
+
+.argo-checkbox input:checked + span {
+    background-color: var(--awf-accent, #00a2b3);
+}

--- a/ui/src/assets/scss/_modern-logs.scss
+++ b/ui/src/assets/scss/_modern-logs.scss
@@ -1,0 +1,215 @@
+// _modern-logs.scss — UI modernization: make the workflow Logs view read as a
+// real terminal console, not spaced-out proportional text in a floating white box.
+//
+// CONTEXT (verified): the log text is rasterised to a <canvas> by xterm.js 4.19
+// (renderer type "canvas"). The glyph metrics are therefore controlled by the
+// xterm Terminal OPTIONS, not by CSS — so the true D1 fix (a real tight monospace
+// stack + letterSpacing:0 + lineHeight:1.2 + fontSize:13) lives in the
+// patch-package hunk on argo-ui's logs-viewer.tsx `new Terminal({...})`. This
+// partial is the COMPLEMENTARY layer:
+//   1. belt-and-braces: pin a true monospace stack + letter-spacing:normal on the
+//      log surface so the xterm char-measure element and any non-canvas fallback
+//      never inherit our global body line-height / label tracking bleed.
+//   2. turn the bare white `.log-box` into a calm, comfortable console surface.
+//
+// NOTE on log-level coloring: per task rules it is SKIPPED here. xterm paints one
+// canvas with no per-line DOM and no per-token class, so coloring is impossible
+// in pure CSS and would require emitting ANSI escapes in the log pipeline
+// (workflow-logs-viewer.tsx rxjs map) — that is parsing/data-flow logic and is
+// explicitly out of scope. We nail readability only.
+//
+// Paint + surface geometry only; no log line is reflowed or restructured.
+//
+// ISOLATION CONTRACT (LOCKED): the logs toolbar layout oscillated across loops
+// because GLOBAL rules bled into it — the shared .argo-button geometry
+// (_modern-buttons.scss: border-radius/padding/font/line-height/transform), the
+// body type scale (_modern-type.scss body line-height:1.5) and the component's
+// own inline `style={{marginBottom:2,marginRight:2}}` on the Log fields Button.
+// To stop the drift, every box-model + text metric of the toolbar inputs and the
+// Log fields button is declared HERE, locally, so global edits can no longer move
+// it. The single `!important` below is the only justified one: it beats the
+// Button component's INLINE margin (inline > class without !important).
+// Local invariants:
+$awf-log-control-h: 34px; // shared control height for every toolbar control
+$awf-log-radius: var(--awf-radius-control, 6px); // shared control corner
+
+// -----------------------------------------------------------------------------
+// (1) MONOSPACE GUARANTEE. Force a real tight monospace stack and neutralise any
+//     letter-spacing on every log surface and on xterm's own measure element.
+//     High enough specificity (and later source order) to beat _modern-type.scss
+//     body rules and argo-ui's `font: ... 'Courier', sans-serif`.
+// -----------------------------------------------------------------------------
+$awf-mono: 'Courier New', Courier, 'Liberation Mono', monospace;
+
+.log-box,
+.log-box .logs-viewer,
+.log-box .logs-viewer__container,
+.logs-viewer,
+.logs-viewer .xterm,
+.logs-viewer .xterm-char-measure-element {
+    font-family: $awf-mono;
+    letter-spacing: normal;
+    // Do NOT set white-space here — xterm manages the canvas + its overlay
+    // measure element itself; forcing white-space could fight its layout. The
+    // monospace stack + letterSpacing is what fixes the spaced-out look.
+}
+
+// -----------------------------------------------------------------------------
+// (2) CONSOLE SURFACE. The bare white floating box becomes a calm, deliberate
+//     console: a very light terminal surface, a hairline border, a soft 8px
+//     radius, and comfortable padding so log lines breathe. The xterm theme
+//     foreground stays --awf-text (#495763) from the patched Terminal options,
+//     so this reads as an intentional light console rather than a white void.
+// -----------------------------------------------------------------------------
+.log-box {
+    box-sizing: border-box;
+    min-height: 320px; // never collapse if global spacing changes the wrapper
+    background-color: var(--awf-tint-1, #f5fbfd);
+    border: 1px solid var(--awf-hairline, #ccd6dd);
+    border-radius: var(--awf-radius-card, 8px);
+    padding: var(--awf-space-4, 16px);
+    box-shadow: var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1));
+
+    // The xterm viewport fills the box; let it scroll comfortably inside the
+    // padded surface without its own background fighting the console tint.
+    .logs-viewer,
+    .xterm,
+    .xterm-viewport,
+    .xterm-screen {
+        background: transparent;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// (3) LOG TOOLBAR REDESIGN (.log-menu). Previously the toolbar was a bare <div>
+//     laid out by whitespace text-nodes + a fa-pull-right float: the POD /
+//     CONTAINER autocompletes, the loud "Log Fields" pill and the grep/timezone
+//     cluster shared no baseline, no gap and no common control height, and the
+//     raw <input type=search> was an unstyled browser default beside the boxed
+//     autocompletes. We rebuild it on Argo CD's toolbar rhythm: ONE flex row,
+//     fields grouped into a left cluster (Pod / Container) and a right cluster
+//     (Filter / Timezone / Log Fields) pushed apart with margin-auto, every
+//     control on one baseline at a shared height, each field carrying a small
+//     UPPERCASE muted-grey mini-label above it (Argo CD's .argo-form-row label
+//     idiom), and the "Log Fields" action given real separation via the grid gap
+//     instead of crowding the inputs. Inputs adopt Argo CD's field look.
+// -----------------------------------------------------------------------------
+.workflow-logs-viewer .log-menu {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end; // align every control on one BASELINE row
+    gap: var(--awf-space-3, 12px) var(--awf-space-5, 20px);
+    margin-bottom: var(--awf-space-3, 12px);
+
+    // Left vs right field clusters. The right cluster is pushed to the far edge
+    // (margin-left:auto) so Filter / Timezone / Log Fields read as their own
+    // group, well clear of Pod / Container — replacing the old fa-pull-right
+    // float that fought the row.
+    &__group {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        gap: var(--awf-space-3, 12px) var(--awf-space-4, 16px);
+    }
+    &__group--end {
+        margin-left: auto;
+    }
+
+    // A field = its uppercase mini-label stacked above the control, so labels
+    // and controls share a vertical rhythm and the controls all bottom-align.
+    &__field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--awf-space-1, 4px);
+        margin: 0; // the element is a <label>; kill the UA default
+    }
+
+    // Small UPPERCASE muted-grey eyebrow label (Argo CD .argo-form-row label).
+    &__label {
+        font-size: var(--awf-font-size-label, 12px);
+        font-weight: var(--awf-weight-medium, 500);
+        letter-spacing: var(--awf-tracking-label, 0.04em);
+        text-transform: uppercase;
+        color: var(--awf-muted, #6d7f8b);
+        line-height: 1.2;
+
+        i {
+            margin-right: var(--awf-space-1, 4px);
+            color: var(--awf-muted, #6d7f8b);
+        }
+    }
+
+    // ALL toolbar controls share one height + one boxed Argo-CD field look so
+    // the autocompletes (rendered as a bare <input> inside .select) and the raw
+    // search input finally match. The autocomplete wrapper is .select; we target
+    // its inner <input> plus the grep search input together.
+    //
+    // ISOLATION: pin EVERY box-model + text metric here. Setting line-height to
+    // the control height and letter-spacing:normal neutralises the global body
+    // line-height (1.5) and any label tracking bleed, so input text stays
+    // vertically centred in the 34px box regardless of future global type edits.
+    .select,
+    .select input,
+    &__search {
+        box-sizing: border-box;
+        height: $awf-log-control-h;
+        line-height: $awf-log-control-h;
+        letter-spacing: normal;
+    }
+
+    .select input,
+    &__search {
+        width: 100%;
+        min-width: 180px;
+        padding: 0 var(--awf-space-3, 12px);
+        font-size: var(--awf-font-size-sm, 13px);
+        color: var(--awf-text, #495763);
+        background-color: var(--awf-surface, #fff);
+        border: 1px solid var(--awf-hairline, #ccd6dd);
+        border-radius: $awf-log-radius;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        -webkit-appearance: none;
+        appearance: none;
+
+        &:focus {
+            outline: 0;
+            border-color: var(--awf-accent, #00a2b3);
+            box-shadow: var(--awf-focus-ring-shadow, 0 0 0 3px rgba(0, 162, 179, 0.28));
+        }
+
+        &::placeholder {
+            color: var(--awf-muted, #6d7f8b);
+        }
+    }
+
+    // The pod/container autocompletes can be a little wider; timezone narrower.
+    &__group:first-child .select {
+        min-width: 220px;
+    }
+
+    // "Log Fields" stays the neutral-grey workhorse pill (Argo CD toolbar action),
+    // sits in its own right-cluster slot, and its baseline matches the 34px
+    // controls. SELF-CONTAINED GEOMETRY: re-declare box-sizing, height,
+    // line-height, padding, radius, font-size/weight, text-transform and the
+    // flex centring locally so the global .argo-button rule
+    // (_modern-buttons.scss: border-radius:14px / padding:8px 18px / font:13px /
+    // line-height:1.4 / transition) can no longer reshape this button — only its
+    // neutral-grey --base FILL is inherited (per the KEEP rule). The `!important`
+    // on margin is REQUIRED to beat the Button component's inline
+    // `style={{marginBottom:2,marginRight:2}}` (inline beats a class otherwise),
+    // which would otherwise nudge the button off the 34px flex baseline.
+    &__action.argo-button {
+        box-sizing: border-box;
+        height: $awf-log-control-h;
+        line-height: $awf-log-control-h;
+        margin: 0 !important; // beat the component's inline 2px margins
+        padding: 0 var(--awf-space-4, 16px);
+        border-radius: $awf-log-radius;
+        font-size: var(--awf-font-size-sm, 13px);
+        font-weight: var(--awf-weight-medium, 500);
+        text-transform: none;
+        display: inline-flex;
+        align-items: center;
+        align-self: flex-end;
+    }
+}

--- a/ui/src/assets/scss/_modern-spacing.scss
+++ b/ui/src/assets/scss/_modern-spacing.scss
@@ -1,0 +1,139 @@
+// _modern-spacing.scss — UI modernization (Stage B): an 8px-grid breathing pass.
+//
+// argo-ui ships a dense 2016 rhythm: cramped tab content, tight 8px row gaps,
+// and content that runs edge-to-edge in narrow gutters. This partial opens the
+// layout up onto the --awf-space-* 8px grid so the UI breathes, WITHOUT moving
+// any JS-driven dimension (nav width, top-bar height, graph nodes, the tabs
+// indicator) — every value below is a padding/margin/gutter that argo-ui (or an
+// app-local partial) paints statically and the cascade can reach.
+//
+// Loaded AFTER argo-ui and the modern-* paint partials so it wins by source
+// order. Geometry-within-component only; no functional regression.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// Page content column: roomier, consistent side gutters on the centred column.
+// argo-ui `.argo-container` ships `padding: 0 80px` on a fixed 1184px box; that
+// is fine on wide screens but the `--additional-padding` variant is a cramped
+// 0 30px. Lift the tighter variant onto the grid and give the page content a
+// little top breathing room so the first card never kisses the top bar.
+// -----------------------------------------------------------------------------
+.argo-container--additional-padding {
+    padding: 0 var(--awf-space-7, 32px);
+}
+
+// Give the main scroll surface real top breathing room so list/detail pages
+// start with air under the toolbar instead of flush content. Safe: it is inside
+// the fixed page frame, below the (unchanged) top-bar/nav offsets.
+.page__content-wrapper {
+    padding-top: var(--awf-space-4, 16px);
+}
+
+// -----------------------------------------------------------------------------
+// Cards / panels: open up the padding from argo-ui's tight defaults onto the
+// grid. White-box ships 30px (acceptable) but its inner detail rows are dense;
+// the sliding panel body/header/footer are the main detail surfaces and read
+// cramped — give them generous, consistent padding.
+// -----------------------------------------------------------------------------
+.sliding-panel__body {
+    padding: var(--awf-space-7, 32px);
+}
+
+.sliding-panel__header,
+.sliding-panel__footer {
+    padding: 0 var(--awf-space-7, 32px);
+}
+
+// White-box: keep 30px outer padding but de-cramp the uppercase heading rhythm
+// and the detail-row gutter so grouped key/value rows breathe.
+.white-box {
+    padding: var(--awf-space-6, 24px) var(--awf-space-7, 32px);
+
+    &__details {
+        padding: 0 var(--awf-space-2, 8px);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Toolbars / option panels: open the cramped 10px option panel and the dense
+// graph-options panel onto the grid so floating controls have comfortable
+// internal padding and separation.
+// -----------------------------------------------------------------------------
+.graph-options-panel {
+    margin: var(--awf-space-3, 12px);
+    padding: var(--awf-space-3, 12px) var(--awf-space-4, 16px);
+}
+
+// -----------------------------------------------------------------------------
+// List heads: argo-ui table heads use `margin: 8px 0`. Give the header row a
+// touch more separation from the first data row so the column labels read as a
+// distinct band rather than crowding the first card.
+// -----------------------------------------------------------------------------
+.argo-table-list__head {
+    margin: var(--awf-space-2, 8px) 0 var(--awf-space-3, 12px);
+    // Loop 10 (item 1): this partial loads AFTER _modern-type, so its tracking
+    // wins the cascade on the header band. Keep it in lockstep with the type
+    // rule's near-zero tracking so dense column labels fit their meta tracks on
+    // one line (the 0.04em eyebrow tracking pushed Started/Finished past the
+    // single-line clamp and they ellipsed). Spacing only.
+    letter-spacing: var(--awf-tracking-label-tight, 0.01em);
+}
+
+// Form rows: argo-ui uses `margin: 32px 0` which is actually generous; keep it,
+// but ensure the field label sits on the grid with comfortable spacing.
+.argo-form-row {
+    margin: var(--awf-space-6, 24px) 0;
+}
+
+// -----------------------------------------------------------------------------
+// LIST PAGE gutter: the workflows list ships a cramped `padding: 1em` (16px).
+// Keep a roomy 24px top/bottom, but EASE the SIDE gutters to 12px now the nav
+// rail is thin: the list uses a Foundation 12-col grid whose right-side columns
+// are rigid `small-1` fractions, so wider side gutters were starving them and
+// the right-most cells (Started/Finished/Duration/Details/Archived) truncated
+// with ellipses in the default viewport. Narrower side gutters hand those
+// fixed-fraction columns more pixels so they stop truncating. Geometry-only;
+// no markup/grid change.
+// -----------------------------------------------------------------------------
+.workflows-list {
+    padding: var(--awf-space-6, 24px) var(--awf-space-3, 12px);
+}
+
+// -----------------------------------------------------------------------------
+// LIST ROW vertical rhythm + DENSITY: argo-ui rows are a single ~52px line with
+// effectively zero cell padding, so content rides the line box (2016-dense).
+// Give every clickable row real vertical air on the 8px grid — a taller line
+// plus explicit top/bottom cell padding so multi-line NAME / MESSAGE breathe —
+// and a roomier inter-row gap so the cards read as discrete, scannable surfaces.
+// Paint/geometry only; no markup, no row-count change.
+// -----------------------------------------------------------------------------
+// NOTE: the row already carries Foundation's `.row` class (display:flex +
+// flex-wrap:wrap), and argo-ui set line-height:60px purely to vertically centre
+// single-line content. We replace that line-box trick with real flex centring +
+// explicit cell padding, so the row breathes AND stays vertically aligned.
+.argo-table-list__row {
+    margin: var(--awf-space-3, 12px) 0; // 12px inter-row gap (was 10px)
+    line-height: var(--awf-line-snug, 1.4); // release the rigid 52/60px line box
+    padding: var(--awf-space-3, 12px) 0; // real vertical air inside the row
+    align-items: center; // centre status col against the content column (flex)
+}
+
+// Centre the nested content grid (the inner `.row`) too, so the name/meta
+// cells sit on the same baseline band as the status pill.
+//
+// Loop 10: the live markup is `small-10 row` (workflows-row.tsx:58), not
+// `small-11` — the old `.small-11.row` selector was stale/dead and the
+// centring never applied. Target `.small-10.row` so the rule lands.
+.argo-table-list__row .small-10.row {
+    align-items: center;
+}
+
+// -----------------------------------------------------------------------------
+// SIDEBAR FILTER sections: the filter sidebars now render `.wf-filters-container`
+// (see workflow-filters / cron / templates / reports). The legacy
+// `.workflows-list__filters-container` accordion this partial used to space is
+// dead and was removed (no .tsx renders it), so the stale spacing block is gone
+// too. The card rhythm now lives with the shared surface in _modern-cards.scss
+// and the per-group `p` margins in each panel's own scss.
+// -----------------------------------------------------------------------------

--- a/ui/src/assets/scss/_modern-status-pill.scss
+++ b/ui/src/assets/scss/_modern-status-pill.scss
@@ -1,0 +1,136 @@
+// _modern-status-pill.scss — UI modernization (Stage 2): readable LABELLED
+// status pill for the workflow LIST.
+//
+// The workflow-list status cell historically showed a bare phase GLYPH (a small
+// FontAwesome icon) with no word — the single most "old admin UI" element on the
+// page. Stage 2 wraps that glyph (markup-only, no logic/data change) in a
+// `.wf-phase-pill` span that also carries the phase WORD already present in
+// props (Succeeded / Failed / Running / Pending / …). This partial paints that
+// span as a tinted-background rounded pill with AA-contrast text in the
+// canonical phase hue, mirroring the proven recipe in _modern-cards.scss
+// (status-badge) and reusing the AA-verified --awf-status-*-text tokens.
+//
+// Loaded AFTER the other modern-* partials (see app-restyle.scss) so equal-
+// specificity geometry wins by source order. Paint + within-component geometry
+// only — no markup is required beyond the one surgical span already added.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// Relax the status COLUMN so the phase word never clips. The app-local rule
+// caps `.workflows-list__status { max-width: 80px }` (workflows-list.scss:21) —
+// fine for a bare icon + checkbox, but far too tight once the full phase WORD is
+// shown. The status column is now a `small-2` grid cell (see workflows-row.tsx
+// and workflows-list.tsx; the sibling block dropped from small-11 to small-10 so
+// the outer row still sums to 12 and the header + body left-edges stay aligned).
+// Lift the legacy 80px cap so the cell can use its full small-2 track, and set a
+// comfortable floor that fits the widest phase word ("Succeeded") plus the
+// checkbox even on narrow viewports. Mirrors the status-badge width:auto /
+// min-width approach in _modern-cards.scss.
+// -----------------------------------------------------------------------------
+.workflows-list__status {
+    max-width: none !important;
+    // checkbox (~16px) + gap (8px) + pill ("Succeeded": ~14px icon + ~70px text
+    // + 4px inner gap + 24px h-padding ≈ 112px) ≈ 140px. Floor it so the pill
+    // never clips, but tie the floor to the viewport with clamp() so a fixed
+    // 150px px-floor can't exceed the small-2 (~16.6%) track on narrow viewports
+    // and squeeze the adjacent Name/Message cells. At >=940px the upper bound
+    // (150px) holds exactly as before; below that the floor relaxes toward 110px
+    // (still wide enough for the widest "Succeeded" pill + checkbox) instead of
+    // overflowing its track. Behaviour-preserving at default desktop widths.
+    min-width: clamp(110px, 16vw, 150px);
+    // Keep checkbox + pill on one calm baseline with an 8px-grid gap.
+    gap: var(--awf-space-2, 8px);
+    overflow: visible;
+}
+
+// The header row reuses the same `.workflows-list__status` class (now a small-2
+// cell with no pill) — the relaxed cap above applies to both header and body, so
+// the grid stays aligned. No extra rule needed.
+
+// -----------------------------------------------------------------------------
+// The pill itself. Tinted-alpha background + AA status text + a comfortable,
+// scannable shape. The leading PhaseIcon glyph keeps its OWN saturated canonical
+// hue (argo-ui's .status-icon--* set the glyph colour directly — see
+// _a11y-paint.scss:96), so the saturated glyph reads as a dot of true phase
+// colour next to the AA-contrast phase WORD: one coherent status token.
+// -----------------------------------------------------------------------------
+.wf-phase-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--awf-space-1, 4px);
+    min-width: 0;
+    padding: var(--awf-space-1, 4px) var(--awf-space-3, 12px);
+    border-radius: var(--awf-radius-pill, 999px);
+    font-size: var(--awf-font-size-sm, 13px);
+    font-weight: var(--awf-weight-medium, 500);
+    line-height: var(--awf-line-snug, 1.4);
+    letter-spacing: 0;
+    text-transform: none;
+    white-space: nowrap;
+
+    // GUARANTEED RIGHT GUTTER (D2 overlap). The status cell sits directly beside
+    // the Name link with no intrinsic separation, so on narrow tracks the long
+    // phase words ("Succeeded"/"Running") push the pill's right edge flush
+    // against the next cell's text. A right margin on the pill itself makes it
+    // impossible for the pill to ever touch a neighbouring cell, on ANY table
+    // that renders it (workflows-list, archived, workflow-details-list — all use
+    // the shared WorkflowsRow). The cron list renders no pill, so it is unaffected.
+    margin-right: var(--awf-space-2, 8px);
+
+    // Default / Unknown / Omitted / '' phase: calm neutral chip.
+    background-color: rgba(109, 127, 139, 0.14);
+    color: var(--awf-status-pending-text, #566a78);
+
+    // GLYPH CENTRING (D2 off-centre). The bare FontAwesome glyph rides the row's
+    // tall line-box by default; the pill's `inline-flex` + `align-items:center`
+    // centres the glyph BOX, but the glyph's own intrinsic line-height/baseline
+    // still let it ride high — most visibly on the Running/Pending spinners whose
+    // rotation rides the cap line. Make the icon its OWN centred inline-flex box
+    // with a line-height tied to the text line-box so its optical centre lines up
+    // with the word's x-height. We deliberately keep `transform-origin` untouched
+    // (no `display` change that would move it) so the FontAwesome spin keeps
+    // rotating about the glyph centre and never wobbles.
+    .fa,
+    i {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+        font-size: 0.95em;
+        // Square the glyph box to its own font-size so centring is symmetric and
+        // the spinner rotates inside a centred box rather than a tall line-box.
+        width: 1em;
+        height: 1em;
+        text-align: center;
+        vertical-align: middle;
+    }
+}
+
+// Per-phase tinted-alpha background + AA phase-word text (the canonical hue at
+// AA contrast). The glyph keeps its own saturated argo-ui hue. Backgrounds match
+// the status-badge recipe in _modern-cards.scss for one consistent status
+// language across the UI.
+.wf-phase-pill--Succeeded {
+    background-color: rgba(24, 190, 148, 0.16);
+    color: var(--awf-status-succeeded-text, #0a7257);
+}
+
+.wf-phase-pill--Running {
+    background-color: rgba(13, 173, 234, 0.16);
+    color: var(--awf-status-running-text, #0a7299);
+}
+
+.wf-phase-pill--Pending {
+    background-color: rgba(244, 192, 48, 0.18);
+    color: var(--awf-status-warning-text, #806100);
+}
+
+.wf-phase-pill--Failed,
+.wf-phase-pill--Error {
+    background-color: rgba(233, 109, 118, 0.18);
+    color: var(--awf-status-failed-text, #be3d47);
+}
+
+// Omitted / Unknown / empty phase keep the neutral default declared on the base
+// `.wf-phase-pill` block above — no per-phase override needed.

--- a/ui/src/assets/scss/_modern-surfaces.scss
+++ b/ui/src/assets/scss/_modern-surfaces.scss
@@ -1,0 +1,53 @@
+// _modern-surfaces.scss — UI modernization: list rows + cards.
+//
+// argo-ui rows/cards use a hard offset drop shadow (`1px 2px 3px rgba(0,0,0,.1)`)
+// and a tight 4px radius. We modernise to a single cohesive soft shadow, an 8px
+// radius, a comfortable hover background, and a slightly tighter row height.
+//
+// Supersedes the inset-hairline flattening in _overrides-tables.scss (kept as a
+// no-op stub). Loaded after argo-ui + that stub, so it wins by source order.
+
+// -----------------------------------------------------------------------------
+// List rows: 4px -> 8px radius, cohesive soft shadow, comfortable hover bg,
+// tighter modern row height (60px -> 52px), roomier vertical gap.
+// -----------------------------------------------------------------------------
+.argo-table-list__row {
+    margin: 10px 0;
+    line-height: 52px;
+    border-radius: var(--awf-radius-card, 8px);
+    box-shadow: var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1));
+
+    .title-text {
+        color: var(--awf-heading, #363c4a);
+        font-weight: var(--awf-weight-semibold, 600);
+    }
+
+    // Clickable hover: lift slightly with the cohesive hover shadow + a teal
+    // hairline ring (box-shadow only — no border, no reflow) and a faint wash.
+    .argo-table-list--clickable &:hover {
+        background-color: var(--awf-tint-1, #f5fbfd);
+        box-shadow: var(--awf-shadow-card-hover, 0 2px 4px rgba(16, 24, 40, 0.08), 0 4px 10px rgba(16, 24, 40, 0.1)),
+            inset 0 0 0 1px rgba(0, 162, 179, 0.35);
+    }
+
+    // Keep the selected-row teal tint readable against the new hover.
+    &.selected {
+        background-color: var(--awf-tint-2, #dff6f9);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// White-box card: 4px -> 8px radius, cohesive soft shadow.
+// (Padding/margins left as argo-ui ships them — geometry is fine; the shadow +
+// radius are the modern tell.)
+// -----------------------------------------------------------------------------
+.white-box {
+    border-radius: var(--awf-radius-card, 8px);
+    box-shadow: var(--awf-shadow-card, 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1));
+}
+
+// Dropdown / popover menus: align to the cohesive pop elevation + card radius.
+.argo-dropdown__content {
+    border-radius: var(--awf-radius-control, 6px);
+    box-shadow: var(--awf-shadow-pop, 0 4px 16px rgba(16, 24, 40, 0.14));
+}

--- a/ui/src/assets/scss/_modern-table.scss
+++ b/ui/src/assets/scss/_modern-table.scss
@@ -1,0 +1,198 @@
+// _modern-table.scss — UI modernization (Stage 2): headline-table refinements
+// for the workflow LIST that build ON the Stage-1 rhythm (row gap, cell padding,
+// taller line) and the Stage-1 type scale (muted meta columns) — NOT a redo.
+//
+// Stage 1 already opened the row vertical rhythm (_modern-spacing.scss) and
+// receded the timestamp/meta columns + promoted the NAME (_modern-type.scss).
+// Stage 2 adds the remaining "modern dashboard" table polish:
+//   1. a quiet HEADER band (the column-header row reads as a calm label strip
+//      sitting just above the cards, separated by a hairline, not a heavy bar);
+//   2. comfortable per-CELL vertical padding so multi-line NAME / MESSAGE wrap
+//      without crowding the row edges;
+//   3. recede the remaining secondary columns (duration / progress) to the same
+//      muted meta treatment the timestamps already use, so NAME + STATUS lead.
+// Hover / selected / radius / shadow are already handled in _modern-surfaces.scss
+// and are intentionally NOT repeated here.
+//
+// Loaded after the other modern-* partials so equal-specificity geometry wins by
+// source order. Paint + within-component geometry only; no markup change.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// QUIET HEADER BAND. The column-header row (`.argo-table-list__head`) is a label
+// strip, not a card: drop any inherited card finish, sit it flush above the rows
+// with comfortable side padding that lines up with the row cells, and rest it on
+// a single hairline so the eye reads "labels, then cards" with no heavy chrome.
+// (Type — size/weight/sentence-case/tracking/colour — is set in _modern-type.)
+// -----------------------------------------------------------------------------
+.argo-table-list__head {
+    background: transparent;
+    box-shadow: none;
+    border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+    padding-bottom: var(--awf-space-2, 8px);
+    line-height: var(--awf-line-snug, 1.4);
+}
+
+// -----------------------------------------------------------------------------
+// HEADER LABELS ON ONE LINE (D3). Root cause (argo-ui table-list.scss): the
+// `white-space:nowrap; overflow:hidden; text-overflow:ellipsis` clamp is applied
+// ONLY to the DATA rows (`.argo-table-list__row .columns`), never to the header
+// cells — so a header label whose text + inline TimestampSwitch toggle exceeds
+// its narrow `small-1` track (1/12 ≈ 8.3%) is free to wrap to two lines. That is
+// exactly the "Started"/"Finished"/"Namespace" cluster the user sees wrapping.
+//
+// Fix: give the header cells the SAME single-line clamp the data cells already
+// have. Each label (incl. its inline clock <TimestampSwitch> anchor, which is an
+// inline element so it sits ON the same line under nowrap) now stays on ONE line.
+// `min-width: 0` lets the flex/grid cell actually shrink so ellipsis can engage
+// instead of forcing a wrap, and the clamp keeps the header left-edges aligned
+// with the nowrap data cells below. Paint/layout-within-component only; no markup.
+// -----------------------------------------------------------------------------
+.argo-table-list__head .columns {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+// -----------------------------------------------------------------------------
+// COLUMN WIDTHS (Loop 10, item 1 — ROOT-CAUSE CORRECTED). The workflow-list head
+// + every data row is a single Foundation 12-unit grid:
+//   Name(2) Namespace(1) Started(1) Finished(1) Duration(1) Progress(1)
+//   Message(2) Details(1) Archived(1) + dynamic custom column(s)(1 each)
+// The fixed columns already sum to exactly 12 units, so at their natural
+// percentage widths the whole header — and the matching data row — lays out on
+// ONE line.
+//
+// The earlier loops tried to widen the meta tracks with `min-width: 9.5em/10em`
+// to stop "Finished"+clock ellipsing. Measured on the live page that backfired:
+// 10 cells × ~104–110px min-width = ~1152px, but the `.row.small-10` container
+// is only ~935px wide. Foundation columns are FLOATS, so once the min-widths
+// overflow the container the row WRAPS — Details/Archived/custom drop onto a
+// second line (header AND rows together). That two-line stack, plus the dynamic
+// "Workflow Completed" custom label overflowing its own forced-narrow track, is
+// exactly the truncation/stacking the critic sees.
+//
+// Fix: DROP the min-width overrides entirely and let each cell use its natural
+// Foundation track. The single 12-unit row then fits on one line with no wrap.
+// Keep the meta horizontal padding trimmed to 6px (from Foundation's 15px
+// gutter) so each label has the most text room inside its natural track; with
+// the 11px head type (_modern-type) the static labels ("Namespace", "Finished "
+// + inline clock, etc.) clear their tracks on one line. The nowrap+ellipsis
+// clamp above stays as a safety net for any over-long dynamic custom label, so
+// it ellipsizes gracefully INSTEAD of wrapping the whole grid to two lines.
+// Applied to head AND row in lockstep so columns stay aligned; no markup/logic
+// and no column-span change.
+// -----------------------------------------------------------------------------
+.argo-table-list__head .columns.small-1,
+.argo-table-list__row .columns.small-1,
+.argo-table-list__head .columns.small-2,
+.argo-table-list__row .columns.small-2 {
+    padding-left: 6px;
+    padding-right: 6px;
+}
+
+// -----------------------------------------------------------------------------
+// DYNAMIC CUSTOM COLUMN headers (Loop 11, item 1). The 11 STATIC cells sum to
+// 11/12 = 91.667% and lay out on one line. A user-defined custom column
+// (`models.Column`, rendered with the extra `workflows-list__custom-col` class
+// on BOTH head and row — className-only edit) is forced into a `small-1` track
+// = 8.333% ≈ 64px text room; a label like "Workflow Completed"/"Workflow Link"
+// needs ~120–135px at the 11px head type, so the nowrap+ellipsis clamp above
+// clips it to "Workflow…". That is the LAST-header truncation the critic sees.
+//
+// Fix (styling only, head+row in lockstep, NO column-span change): let the
+// custom cell size to its CONTENT instead of the rigid 1/12 track. `flex-basis:
+// auto` + `max-width: none` releases the Foundation `flex: 0 0 8.333%` cap so
+// the cell is exactly as wide as its label/value (still `nowrap`, so it stays
+// on one line and the header reads in full — no ellipsis). The 11 static cells
+// keep their tracks (Σ = 91.667% ≤ 100%), so ONE content-sized custom cell uses
+// the remaining ~8.3% slack and the single grid row stays on one line with no
+// wrap. (Two-plus custom columns can exceed 100% and trigger the pre-existing
+// horizontal scroll, which is acceptable.) Applied to head AND row together so
+// the column stays aligned; no markup/logic and no span change.
+// -----------------------------------------------------------------------------
+.argo-table-list__head .columns.workflows-list__custom-col,
+.argo-table-list__row .columns.workflows-list__custom-col {
+    flex-basis: auto;
+    max-width: none;
+    white-space: nowrap;
+    overflow: visible;
+    text-overflow: clip;
+}
+
+// -----------------------------------------------------------------------------
+// KEEP THE 11-UNIT GRID ON ONE LINE (Loop 11, item 1 — the actual root cause).
+// argo-ui ships the FLEX grid (`@include foundation-flex-grid`), so the inner
+// content container `.small-10.row` is `display:flex; flex-wrap:wrap`. The 9
+// static cells (Name small-2 + Namespace/Started/Finished/Duration/Progress +
+// Message small-2 + Details + Archived) already sum to 11/12 = 91.667%, leaving
+// only 8.333% (~78px at the 1440 viewport) of track for a custom column. The
+// content-sized custom cell above needs ~120–135px for a label like "Workflow
+// Completed"/"Workflow Link", so under `flex-wrap:wrap` it WRAPS onto a second
+// line and the header reads as a clipped/stacked "Workflow…". That wrap — NOT a
+// per-cell ellipsis — is the last-header truncation.
+//
+// Fix (styling only, head + row in lockstep, no span change): pin the inner
+// content row to `flex-wrap: nowrap` so every cell — including the content-sized
+// custom column — stays on ONE line and the full header label is visible. With
+// nowrap the flex cells lay out left-to-right without ever dropping to a second
+// row; the static cells keep their tracks and the custom cell takes its content
+// width. If two-plus custom columns push the total past 100%, the row scrolls
+// horizontally (the pre-existing, acceptable behaviour) instead of wrapping. The
+// head and the data row use the SAME inner `.small-10.row` container, so they
+// stay column-aligned. No markup/logic change.
+// -----------------------------------------------------------------------------
+.argo-table-list__head .small-10.row,
+.argo-table-list__row .small-10.row {
+    flex-wrap: nowrap;
+}
+
+// With nowrap, the content-sized custom cell (~126px for "Workflow Completed")
+// would push the inner row's total past the ~935px `.small-10` container by the
+// ~48px it claims beyond its old 1/12 track, overflowing the page's right edge.
+// Let the two WIDE static cells (Name + Message, both `small-2`) give that space
+// back: allow them to shrink below their Foundation flex-basis so the nowrap row
+// compresses to fit the container exactly (Σ ≤ container, no wrap, no ellipsis,
+// no horizontal overflow). `min-width: 0` is required for a flex item to shrink
+// below its content/track; `flex-shrink: 1` opts them back into shrinking (the
+// Foundation `.columns` default is `flex-shrink: 0`). The narrow meta cells keep
+// their fixed tracks so the columns stay aligned head-to-row. Name/Message text
+// already wrap/clip gracefully inside their own cells. Head + row in lockstep.
+.argo-table-list__head .small-10.row > .columns.small-2,
+.argo-table-list__row .small-10.row > .columns.small-2 {
+    flex-shrink: 1;
+    min-width: 0;
+}
+
+// -----------------------------------------------------------------------------
+// CELL vertical breathing. The row itself got top/bottom padding in Stage 1, but
+// individual columns still butt against each other when MESSAGE / NAME wrap to a
+// second line. Give each cell a small symmetric vertical pad so wrapped content
+// has air without disturbing the single-line vertical centring. Keep it modest
+// (4px) so single-line rows do not grow; the row's flex `align-items:center`
+// (Stage 1) keeps everything on one band.
+// -----------------------------------------------------------------------------
+.argo-table-list__row .columns {
+    padding-top: var(--awf-space-1, 4px);
+    padding-bottom: var(--awf-space-1, 4px);
+}
+
+// -----------------------------------------------------------------------------
+// SECONDARY-COLUMN HIERARCHY (UX). Stage 1 receded only the timestamp cells when
+// the ISO toggle was on, and could not safely touch Duration / Progress because
+// those cells carried no stable class (a positional nth-of-type rule among the
+// small-2 anchor + dynamic label columns would be brittle). Stage 2 adds a stable
+// `.workflows-list__meta` class to the Namespace / Started / Finished / Duration /
+// Progress cells (className-only edit in workflows-row.tsx — no logic/data change),
+// so the secondary reference columns can now be receded RELIABLY. The NAME link
+// stays at heading colour + semibold (_modern-type.scss) and the STATUS pill keeps
+// its colour, so NAME + STATUS lead the scan and the meta columns recede behind
+// them. The Message and Details/Archived/label cells are intentionally left at body
+// treatment (Message can carry an important error; Details is an action control).
+// -----------------------------------------------------------------------------
+.workflows-list__meta {
+    font-size: var(--awf-font-size-meta, 12px);
+    color: var(--awf-muted-aa, #556472);
+}

--- a/ui/src/assets/scss/_modern-tabs.scss
+++ b/ui/src/assets/scss/_modern-tabs.scss
@@ -1,0 +1,74 @@
+// _modern-tabs.scss — UI modernization: underline tabs (de-boxed).
+//
+// argo-ui tabs are a boxed/elevated bar (`box-shadow:0 1px 3px ...`) with
+// UPPERCASE links and heavy `padding:12px 36px`. We convert to modern underline
+// tabs: a flat bar with a 1px hairline baseline, sentence-case links, slimmer
+// padding, and the EXISTING 2px teal `.tabs__indicator` as the active underline.
+//
+// The indicator is JS-positioned (tabs.tsx sets left/width at runtime) — we only
+// restyle its static look (colour/height/radius), never its position mechanism.
+//
+// Loaded AFTER argo-ui and after _overrides-chrome (icon colour) so this wins.
+
+.tabs__nav {
+    // Drop the elevated boxed look for a flat underlined bar.
+    box-shadow: none;
+    border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+    padding: 0 4px;
+    background-color: var(--awf-surface, #fff);
+
+    a {
+        margin: 0 4px;
+        padding: 12px 16px;
+        font-size: var(--awf-font-size-sm, 13px);
+        font-weight: var(--awf-weight-medium, 500);
+        letter-spacing: 0;
+        text-transform: none;
+        color: var(--awf-muted-aa, #556472);
+        // Give inactive tabs a tiny transparent baseline so the hover/active
+        // states sit on a consistent rhythm with the moving indicator.
+        border-bottom: 2px solid transparent;
+        transition: color 0.15s ease, border-color 0.15s ease;
+
+        &:hover {
+            color: var(--awf-heading, #363c4a);
+        }
+
+        &.active {
+            color: var(--awf-accent, #00a2b3);
+            font-weight: var(--awf-weight-semibold, 600);
+        }
+
+        i {
+            color: var(--awf-muted-aa, #556472);
+        }
+    }
+
+    // The transparent tab variant already has a hairline baseline; align its
+    // active colour and de-uppercase via the inherited rules above.
+    &.transparent {
+        border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+
+        a.active {
+            color: var(--awf-accent, #00a2b3);
+        }
+    }
+}
+
+// Active underline: keep the existing 2px teal bar, just align the hue to the
+// accent token and sit it flush on the baseline. Position is JS-driven — DO NOT
+// set left/width/right here.
+.tabs__indicator {
+    height: 2px;
+    background: var(--awf-accent, #00a2b3);
+    border-radius: 1px;
+}
+
+// Open up the cramped 16px tab content padding onto the 8px grid.
+.tabs__content {
+    padding: var(--awf-space-5, 20px);
+
+    &--no-padding {
+        padding: 0;
+    }
+}

--- a/ui/src/assets/scss/_modern-toolbar.scss
+++ b/ui/src/assets/scss/_modern-toolbar.scss
@@ -1,0 +1,120 @@
+// _modern-toolbar.scss — UI modernization (Loop 4, Stage 3): a consistent
+// button + spacing SYSTEM for toolbars, button groups and the pagination
+// control, plus calm polish on the info-blurb footnote.
+//
+// CONTEXT (verified): the de-pill pass in _modern-buttons.scss dropped the old
+// 24px pill radius (and the visual air it implied) but never added an explicit
+// inter-button gap, so adjacent bare `.argo-button` siblings now share an edge.
+// The headline symptom (D4) is pagination-panel.tsx's two raw
+// `<button className='argo-button argo-button--base-o'>` ('First page' /
+// 'Next page') touching with nothing between them — they are bare siblings
+// inside a <p>, not a flex group, so a sibling-margin rule (not flex `gap`) is
+// the robust, zero-markup fix that also covers every other adjacent pair.
+//
+// argo-ui has NO `.argo-button-group` segmented control anywhere in this app
+// (verified by grep across src/ and node_modules/argo-ui/src/), so the simple
+// adjacency selector is safe app-wide and will not break any deliberately
+// joined control.
+//
+// Loaded AFTER _modern-buttons so it wins by source order. Spacing/geometry
+// only; no markup, no logic, no functional regression.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+// -----------------------------------------------------------------------------
+// (D4) ADJACENT-BUTTON GAP. Any time two buttons sit side by side, guarantee a
+//      consistent 8px-grid gap so no two controls ever touch. Covers the
+//      pagination First/Next pair, the log-fields cluster, and every toolbar
+//      that lays out consecutive `.argo-button`s. The shared <Button> wrapper
+//      (button.tsx) ships an inline marginRight:2 / marginBottom:2; this rule's
+//      8px margin-left supersedes that 2px for true adjacency while the inline
+//      marginBottom still gives wrapped rows their vertical air.
+// -----------------------------------------------------------------------------
+.argo-button + .argo-button {
+    margin-left: var(--awf-space-2, 8px);
+}
+
+// -----------------------------------------------------------------------------
+// SHARED <Button> SPACING (replaces the inline-style trap). The shared <Button>
+// wrapper (shared/components/button.tsx) used to hard-code
+// `style={{marginBottom:2, marginRight:2}}`. An inline style cannot be beaten by
+// a class rule, so any partial that needed to zero that margin (e.g. the logs
+// "Log fields" button) was forced to use `!important`, and the 2px nudged
+// Buttons off toolbar baselines (documented logs-layout regression cause). The
+// Button component now applies this CLASS instead of the inline style, so the
+// exact same 2px breathing room is preserved for normal Buttons while remaining
+// overridable by ordinary cascade order — no `!important` needed downstream.
+// The marginRight is harmless next to the `.argo-button + .argo-button` 8px
+// adjacency rule above (that rule's margin-left wins for true side-by-side
+// pairs); the marginBottom gives wrapped Button rows their vertical air.
+// -----------------------------------------------------------------------------
+.argo-button.awf-btn-spaced {
+    margin-bottom: 2px;
+    margin-right: 2px;
+}
+
+// -----------------------------------------------------------------------------
+// CONTROL-HEIGHT NORMALISATION. Toolbars mix `.argo-button` (8px+1.4 line),
+// `.argo-button--sm` (28px line) and the inline `.argo-select`. Give the
+// pagination + toolbar selects the same control height family so a row of
+// mixed controls sits on one clean baseline instead of stair-stepping.
+// (Inputs/selects already box at 38px via _modern-inputs; here we only align
+// the small inline select used inside the pagination footer.)
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// PAGINATION CONTROL. The panel is a single <p> that floated its "results per
+// page" select to the right via `fa-pull-right` and reserved space with an
+// inline style={{paddingBottom:'45px'}}. Promote it to a calm, aligned bar:
+// a flex row that vertically centres the buttons, the warning text and the
+// right-aligned page-size select on one baseline, with consistent 8px rhythm.
+// The `.wf-pagination` class is added markup-only in pagination-panel.tsx.
+// -----------------------------------------------------------------------------
+.wf-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--awf-space-2, 8px);
+    margin: var(--awf-space-4, 16px) 0 var(--awf-space-6, 24px);
+
+    // The buttons already get their adjacency gap from the rule above; with the
+    // flex `gap` here their inherited inline marginRight:2 is harmless. Keep the
+    // First/Next pair tight-but-separated and let the warning text breathe.
+    .argo-button {
+        margin: 0; // flex `gap` owns the spacing; drop any stray inline-ish gap
+    }
+
+    // Push the "results per page" select cluster to the right edge of the bar
+    // without the old float hack, and centre its label + control.
+    .fa-pull-right {
+        margin-left: auto;
+        display: inline-flex;
+        align-items: center;
+        gap: var(--awf-space-2, 8px);
+        float: none; // neutralise Foundation's fa-pull-right float inside flex
+    }
+
+    // The inline page-size select: a compact boxed control that matches the
+    // button height instead of the full 38px field box.
+    select.small {
+        height: 30px;
+        padding: 0 var(--awf-space-2, 8px);
+        margin: 0;
+    }
+}
+
+// -----------------------------------------------------------------------------
+// INFO-BLURB FOOTNOTE. The shared <Footnote> (footnote.tsx) renders the cron /
+// templates "what is this?" helper text with a flat inline `margin:20px`. Give
+// it a calm, receded treatment: muted text, a hairline top rule separating it
+// from the list above, and consistent 8px-grid spacing so the helper reads as
+// a quiet footer rather than another body paragraph.
+// -----------------------------------------------------------------------------
+.wf-footnote {
+    margin: var(--awf-space-5, 20px) 0 0;
+    padding-top: var(--awf-space-4, 16px);
+    border-top: 1px solid var(--awf-hairline, #ccd6dd);
+    color: var(--awf-muted-aa, #556472);
+    font-size: var(--awf-font-size-sm, 13px);
+    line-height: var(--awf-line-snug, 1.4);
+}

--- a/ui/src/assets/scss/_modern-type.scss
+++ b/ui/src/assets/scss/_modern-type.scss
@@ -1,0 +1,136 @@
+// _modern-type.scss — UI modernization: a calm 2025 type scale.
+//
+// The single strongest "old admin UI" tell in argo-ui is `text-transform:
+// uppercase` EVERYWHERE (table heads, form labels, top-bar title, white-box h6;
+// buttons & tabs are de-uppercased in their own partials). Removing it plus a
+// tightened, neutral heading scale instantly reads modern.
+//
+// Loaded AFTER argo-ui (and the font-family override). Family stays the
+// native/Inter stack from _font-override.scss.
+
+// -----------------------------------------------------------------------------
+// Body base: 16px -> 14px with a comfortable 1.5 line-height.
+// -----------------------------------------------------------------------------
+body {
+    font-size: var(--awf-font-size-body, 14px);
+    line-height: var(--awf-line-body, 1.5);
+    color: var(--awf-text, #495763);
+}
+
+// -----------------------------------------------------------------------------
+// Headings: argo-ui paints h1/h2 teal and leans on near-identical sizes, so the
+// hierarchy reads as colour-only. Repaint calm/neutral AND give each level an
+// explicit SIZE step (page title 22 / section 18 / sub 16 / 14) so the document
+// outline is legible at a glance. Comfortable ~1.4 line-height for headings.
+// -----------------------------------------------------------------------------
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    color: var(--awf-heading, #363c4a);
+    font-weight: var(--awf-weight-semibold, 600);
+    line-height: var(--awf-line-snug, 1.4);
+    letter-spacing: -0.01em;
+}
+
+// Visible SIZE steps. Page title leads; section/sub recede in even ~1.2 ratio.
+h1 {
+    font-size: var(--awf-font-size-page-title, 22px); // page title
+    line-height: var(--awf-line-tight, 1.3);
+}
+
+h2 {
+    font-size: var(--awf-font-size-section, 18px); // section heading
+}
+
+h3 {
+    font-size: var(--awf-font-size-subheading, 16px); // sub-heading
+}
+
+h4,
+h5,
+h6 {
+    font-size: var(--awf-font-size-body, 14px); // minor heading / label-ish
+}
+
+// -----------------------------------------------------------------------------
+// De-uppercase the remaining argo-ui small-caps surfaces and give the genuinely
+// "eyebrow" ones (table heads, form labels) calm tracking at sentence case.
+// -----------------------------------------------------------------------------
+
+// Table list column headers: 11px, sentence case, muted, near-zero tracking.
+//
+// Loop 10 (item 1): the header labels share the narrow Foundation `small-1`
+// meta tracks with the data rows; the 0.04em tracking + 12px size pushed
+// "Started"/"Finished" (+ inline clock) past the single-line clamp and they
+// ellipsed. Dropping the head to 11px and trimming tracking toward 0 reduces
+// the TEXT footprint inside the existing track so every label fits on one
+// line, WITHOUT touching the column width — so head stays aligned with rows.
+.argo-table-list__head {
+    font-size: var(--awf-font-size-label-sm, 11px);
+    font-weight: var(--awf-weight-semibold, 600);
+    text-transform: none;
+    letter-spacing: var(--awf-tracking-label-tight, 0.01em);
+    color: var(--awf-muted-aa, #556472);
+}
+
+// Form-row labels: were `13px uppercase`. Sentence case, medium weight, muted.
+.argo-form-row label:not(.argo-label-placeholder) {
+    text-transform: none;
+    font-size: var(--awf-font-size-sm, 13px);
+    font-weight: var(--awf-weight-medium, 500);
+    letter-spacing: 0;
+    color: var(--awf-muted-aa, #556472);
+}
+
+// Top-bar page title: was `.925em uppercase teal-7`. Sentence case, neutral,
+// a touch bolder so the page identity still leads.
+//
+// Loop 6 (#3 all-caps): argo-ui's `.top-bar__title { text-transform:uppercase }`
+// lives in top-bar.scss, which the TopBar component injects at RUNTIME via
+// `require('./top-bar.scss')` + style-loader — so it lands AFTER our statically
+// bundled app-restyle entry and an equal-specificity (0,1,0) rule here loses the
+// cascade. Scope under `.top-bar` for (0,2,0) so the sentence-case wins by
+// specificity regardless of injection order. Paint-only.
+.top-bar .top-bar__title {
+    text-transform: none;
+    font-weight: var(--awf-weight-semibold, 600);
+    font-size: 15px;
+    letter-spacing: 0;
+    color: var(--awf-heading, #363c4a);
+}
+
+// White-box section heading (h6): was `16px uppercase gray-9`. Sentence case at
+// the sub-heading step. (Overrides the generic h6=14px rule above by being more
+// specific + later in source order.)
+.white-box h6 {
+    text-transform: none;
+    font-size: var(--awf-font-size-h-sm, 16px);
+    font-weight: var(--awf-weight-semibold, 600);
+    letter-spacing: 0;
+    color: var(--awf-heading, #363c4a);
+}
+
+// -----------------------------------------------------------------------------
+// META / SECONDARY columns: timestamps + the started/finished/duration/progress
+// cells on a workflow row are reference data, not the headline. Recede them to a
+// smaller muted treatment so the NAME + STATUS lead the scan. Paint-only; the
+// markup/data are untouched. The NAME cell stays at body weight/size and leads.
+// -----------------------------------------------------------------------------
+.workflows-list__timestamp {
+    font-size: var(--awf-font-size-meta, 12px);
+    color: var(--awf-muted-aa, #556472);
+    line-height: var(--awf-line-snug, 1.4);
+}
+
+// Promote the workflow NAME so it leads the row (the name link renders markdown,
+// not .title-text, and the .wf-rows-name wrapper is only present when there is a
+// description — so target the name LINK itself: the first small-2 anchor inside
+// the row's content column). Paint/weight only; the link, its href and handlers
+// are untouched.
+.workflows-list__row-container a.columns.small-2 {
+    color: var(--awf-heading, #363c4a);
+    font-weight: var(--awf-weight-semibold, 600);
+}

--- a/ui/src/assets/scss/_overrides-app-strays.scss
+++ b/ui/src/assets/scss/_overrides-app-strays.scss
@@ -1,0 +1,17 @@
+// Cascade overrides: app stray hex literals (paint-level only).
+// COLOR ONLY. Out-specify the muted-text literal (#6d7f8b) used as normal text
+// so it meets AA contrast on white.
+//
+// Verified app sources using #6d7f8b as text:
+//   shared/components/object-editor/object-editor.scss  .object-editor       color #6d7f8b
+//   shared/components/editors/object-parser.scss        .object-parser__icon color #6d7f8b
+//
+// #fff surfaces and the login orange are intentionally left untouched.
+
+.object-editor {
+    color: var(--awf-muted-aa);
+}
+
+.object-parser__icon {
+    color: var(--awf-muted-aa);
+}

--- a/ui/src/assets/scss/_overrides-buttons.scss
+++ b/ui/src/assets/scss/_overrides-buttons.scss
@@ -1,0 +1,9 @@
+// Cascade overrides: buttons.
+//
+// SUPERSEDED: the full button modernization (de-pill, solid-teal primary, ghost
+// secondary, focus rings, sizing) now lives in `_modern-buttons.scss`, which is
+// @use'd from app-restyle.scss AFTER this file so it wins by source order.
+//
+// This file intentionally declares no rules; it is kept so the existing
+// `@use 'overrides-buttons'` in app-restyle.scss remains valid and the cascade
+// order documented there is unchanged. See _modern-buttons.scss for the styling.

--- a/ui/src/assets/scss/_overrides-chrome.scss
+++ b/ui/src/assets/scss/_overrides-chrome.scss
@@ -1,0 +1,15 @@
+// Cascade overrides: misc chrome (paint-level only).
+//
+// Most of this file's original scope has moved into the modern-* partials:
+//   - tab icon colour            -> _modern-tabs.scss
+//   - .argo-field border/radius  -> _modern-inputs.scss
+//   - dropdown elevation         -> _modern-surfaces.scss
+//
+// What remains here is the single hairline that has no other home.
+//
+// COLOR / BORDER-COLOR ONLY. Borders stay 1px — only colour changes.
+
+// Sliding-panel footer hairline (#c6cfd1) -> palette hairline (1px unchanged).
+.sliding-panel__footer {
+    border-top-color: var(--awf-hairline);
+}

--- a/ui/src/assets/scss/_overrides-tables.scss
+++ b/ui/src/assets/scss/_overrides-tables.scss
@@ -1,0 +1,8 @@
+// Cascade overrides: table-list elevation.
+//
+// SUPERSEDED: row geometry + elevation (8px radius, cohesive soft shadow,
+// comfortable hover background, tighter row height) now lives in
+// `_modern-surfaces.scss`, @use'd from app-restyle.scss AFTER this file.
+//
+// This file intentionally declares no rules; it is kept so the existing
+// `@use 'overrides-tables'` in app-restyle.scss remains valid.

--- a/ui/src/assets/scss/_overrides-topbar.scss
+++ b/ui/src/assets/scss/_overrides-topbar.scss
@@ -1,0 +1,9 @@
+// Cascade overrides: top bar chrome (paint-level only).
+// Loaded AFTER argo-ui so these win by source order.
+// COLOR / BACKGROUND / BOX-SHADOW ONLY — no box dimensions touched.
+
+// Top-bar filter "selected" dot. argo-ui paints this ::before #009BFF.
+// Re-tint to the accent token; do NOT touch its size/position.
+.top-bar__filter--selected::before {
+    background-color: var(--awf-accent);
+}

--- a/ui/src/assets/scss/_tokens.scss
+++ b/ui/src/assets/scss/_tokens.scss
@@ -1,0 +1,124 @@
+// _tokens.scss — UI modernization design tokens, LIGHT mode only.
+//
+// Declares ONLY CSS custom properties. No painting selectors live here, so
+// forwarding/using this partial is side-effect free except for the :root block.
+//
+// These mirror the argo-ui theme.scss LIGHT branch. The argo-ui gray/teal ramps
+// already equal the target palette, so these tokens exist mainly to give later
+// restyle steps stable, semantic names (and to carry the AA-corrected text
+// variants that the raw ramps do not provide).
+//
+// Every *-aa / *-text / link / focus value below is verified >= 4.5:1 contrast
+// against its intended background. Do NOT substitute other values.
+
+:root {
+    // --- Surfaces & structure --------------------------------------------
+    --awf-canvas: #dee6eb; // app background (argo gray-3)
+    --awf-surface: #ffffff; // cards, panels, rows
+    --awf-text: #495763; // body text (argo gray-7)
+    --awf-heading: #363c4a; // headings (argo gray-8)
+    --awf-muted: #6d7f8b; // secondary / de-emphasised text
+    --awf-hairline: #ccd6dd; // 1px separators / borders that already exist
+    --awf-accent: #00a2b3; // primary teal accent
+    --awf-active: #1fbdd0; // brighter teal for active/hover chrome
+    --awf-tint-1: #f5fbfd; // faint teal wash
+    --awf-tint-2: #dff6f9; // stronger teal wash
+    --awf-chrome: #1a1c22; // dark chrome (top bar / nav background)
+
+    // --- AA text variants (>= 4.5:1) -------------------------------------
+    --awf-muted-aa: #556472; // muted text that still meets AA on white
+    --awf-link-aa: #00808e; // link teal meeting AA on white
+    --awf-focus-ring: #00808e; // visible focus outline colour
+
+    // --- Nav ------------------------------------------------------------
+    // Thin icon RAIL (argo-ui's original $nav-width 60px). This width is the
+    // single source of truth: the argo-ui nav-bar patch sizes the rail to it,
+    // and _modern-chrome re-points the page frame (.page padding-left,
+    // .page__top-bar left, .workflows-toolbar width) at the same token so they
+    // stay in lockstep. The rail keeps the nicer navy + active state but stays
+    // narrow so it NEVER overlaps or dominates page content.
+    --awf-nav-width: 60px; // argo-ui original $nav-width (thin icon rail)
+    --awf-nav-bg: #0f2733; // Argo CD sidebar navy (NOT near-black, NOT gradient)
+    --awf-nav-inactive: #818d94; // Argo CD $deselected-text muted slate label
+    --awf-nav-active-icon: #fe733f; // Argo CD orange active-icon rail accent
+
+    // --- Status text (AA on light status backgrounds / white) ------------
+    --awf-status-succeeded-text: #0a7257;
+    --awf-status-running-text: #0a7299;
+    --awf-status-failed-text: #be3d47;
+    --awf-status-warning-text: #806100;
+    --awf-status-pending-text: #566a78;
+
+    // --- Accent interaction states ---------------------------------------
+    // Darker teal for the solid-primary hover/active so white labels keep AA.
+    --awf-accent-hover: #008291; // hover for solid teal primary
+    --awf-accent-active: #006e7b; // pressed/active for solid teal primary
+    --awf-ghost-hover: #f0f7f9; // faint teal wash for ghost/secondary hover
+
+    // --- Neutral button system (Argo CD .argo-button--base workhorse) -----
+    // Argo CD's primary toolbar button is a NEUTRAL GREY pill (gray-6 #6d7f8b
+    // bg, gray-1 text), NOT a colour fill. Argo's literal gray-6/gray-1 pair is
+    // only 3.99:1 (below AA 4.5:1), so we nudge the resting fill one step darker
+    // to #5a6b78 (5.30:1) — visually the same neutral slate, but AA-clean — and
+    // keep the "hover lightens" direction with an AA-clean lighter grey.
+    // Nudged toward Argo CD's flatter, slightly-less-saturated neutral grey
+    // (less blue/slate cast) while staying AA-clean against the near-white label.
+    --awf-btn-neutral: #5e6973; // resting neutral button fill (5.39:1 vs gray-1)
+    --awf-btn-neutral-hover: #67727c; // hover: lighter grey, still AA (4.72:1)
+    --awf-btn-neutral-active: #555f68; // pressed: slightly darker (6.26:1)
+    --awf-btn-on-neutral: #f8fbfb; // near-white label on the neutral fill (gray-1)
+    --awf-btn-disabled-bg: #ccd6dd; // Argo gray-4 disabled fill
+    --awf-btn-disabled-text: #6d7f8b; // Argo gray-6 disabled label
+    --awf-teal-5: #1fbdd0; // teal-5 — focus ring + outline border only
+
+    // --- Radius scale -----------------------------------------------------
+    // Modern, flat geometry: small controls 6px, cards/rows 8px.
+    --awf-radius-control: 6px; // buttons, inputs, selects, small chips
+    --awf-radius-card: 8px; // list rows, white-box cards, panels
+    --awf-radius-pill: 999px; // intentional pills (status badges, counters)
+
+    // --- 8px spacing grid -------------------------------------------------
+    --awf-space-1: 4px;
+    --awf-space-2: 8px;
+    --awf-space-3: 12px;
+    --awf-space-4: 16px;
+    --awf-space-5: 20px;
+    --awf-space-6: 24px;
+    --awf-space-7: 32px;
+    --awf-space-8: 40px;
+
+    // --- Type scale -------------------------------------------------------
+    // A clear, modular step set so hierarchy is legible by SIZE (not colour
+    // alone): page title leads, then section heading, sub-heading, body, then
+    // small/meta receding text. Semantic role aliases (page-title/section/sub)
+    // map onto the h-lg/md/sm steps so call sites read intent, not magnitudes.
+    --awf-font-size-meta: 12px; // timestamps / secondary list columns (recedes)
+    --awf-font-size-body: 14px;
+    --awf-font-size-sm: 13px; // dense table rows, secondary controls
+    --awf-font-size-label: 12px; // table headers, eyebrow labels
+    --awf-font-size-label-sm: 11px; // dense list-table column headers (fit one line)
+    --awf-font-size-h-sm: 16px; // sub-heading
+    --awf-font-size-h-md: 18px; // section heading
+    --awf-font-size-h-lg: 22px; // page title
+    // Semantic heading-role aliases (visible SIZE steps for the type scale).
+    --awf-font-size-page-title: var(--awf-font-size-h-lg); // 22px
+    --awf-font-size-section: var(--awf-font-size-h-md); // 18px
+    --awf-font-size-subheading: var(--awf-font-size-h-sm); // 16px
+    --awf-line-body: 1.5;
+    --awf-line-snug: 1.4; // comfortable for headings / pills / meta
+    --awf-line-tight: 1.3;
+    --awf-weight-regular: 400;
+    --awf-weight-medium: 500;
+    --awf-weight-semibold: 600;
+    --awf-tracking-label: 0.04em; // tracking for small uppercase eyebrow labels
+    --awf-tracking-label-tight: 0.01em; // near-zero tracking for dense column headers
+
+    // --- Elevation --------------------------------------------------------
+    // One cohesive soft shadow (replaces stacked 1/2/3px offset drop shadows).
+    --awf-shadow-card: 0 1px 2px rgba(16, 24, 40, 0.06), 0 1px 3px rgba(16, 24, 40, 0.1);
+    --awf-shadow-card-hover: 0 2px 4px rgba(16, 24, 40, 0.08), 0 4px 10px rgba(16, 24, 40, 0.1);
+    --awf-shadow-pop: 0 4px 16px rgba(16, 24, 40, 0.14); // dropdowns/menus
+
+    // --- Focus ring (teal, painted via box-shadow so it never reflows) ----
+    --awf-focus-ring-shadow: 0 0 0 3px rgba(0, 162, 179, 0.28);
+}

--- a/ui/src/assets/scss/app-restyle.scss
+++ b/ui/src/assets/scss/app-restyle.scss
@@ -1,0 +1,85 @@
+// app-restyle.scss — app-local ENTRY for the UI modernization restyle.
+//
+// This is the single file imported by app.tsx (immediately AFTER argo-ui's
+// main.scss). Importing it after argo-ui ensures any painting rules here win by
+// cascade order without changing specificity or geometry.
+//
+// FOUNDATION stage scope: bring in the design tokens and the font override.
+// Later stages add their own painting partials and @forward/@use them here.
+//
+// Rules:
+//   - Use @use / @forward (module system), never @import.
+//   - For any colour math use sass:color, never darken()/lighten().
+// so this entry adds ZERO new Sass deprecation warnings.
+
+@forward 'tokens';
+@use 'font-override';
+
+// CASCADE OVERRIDE partials. These load AFTER argo-ui's main.scss (because this
+// entry is imported after it in app.tsx) and win by source order. Each rule is
+// paint-level only: colour / background / border-color / box-shadow.
+@use 'overrides-topbar';
+@use 'overrides-buttons';
+@use 'overrides-tables';
+@use 'overrides-chrome';
+@use 'overrides-app-strays';
+
+// MODERNIZATION partials (bold, visible). Loaded AFTER the legacy override
+// partials so the new geometry/elevation/type wins by source order. Each builds
+// on the --awf-* tokens (radius / spacing / type / elevation scales). Paint AND
+// layout-within-component geometry is intentionally in play here; no functional
+// regression and nothing visually broken.
+@use 'modern-type';
+@use 'modern-buttons';
+@use 'modern-inputs';
+@use 'modern-tabs';
+@use 'modern-surfaces';
+
+// Stage B modernization: 8px-grid spacing rhythm, cohesive cards / panels /
+// elevation, status pills, and crisp flat nav + top-bar chrome. Loaded after the
+// Stage A modern-* partials so the bolder geometry/elevation wins by source
+// order; each builds on the same --awf-* tokens.
+@use 'modern-spacing';
+@use 'modern-cards';
+@use 'modern-chrome';
+
+// Stage 3 (Loop 4): consistent button + spacing SYSTEM. Adjacent-button gap
+// (fixes D4 touching pagination buttons), normalised pagination control bar,
+// and a calm muted info-blurb footnote. Loaded after modern-buttons/spacing so
+// the adjacency gap and the pagination flex bar win by source order.
+@use 'modern-toolbar';
+
+// Stage 2 modernization: headline workflow-LIST table polish (quiet header band,
+// per-cell breathing) and the readable LABELLED status pill that carries the
+// phase WORD. Loaded after the Stage-B card/surface partials so the pill + table
+// geometry win by source order; both build on the same --awf-* tokens and the
+// AA-verified --awf-status-*-text variants.
+@use 'modern-table';
+@use 'modern-status-pill';
+
+// Stage 1 (Loop 4) modernization: make the workflow Logs view a real terminal
+// console. The true glyph-metric fix is the xterm Terminal-options patch hunk
+// (argo-ui logs-viewer.tsx); this partial is the belt-and-braces monospace
+// guarantee + the calm console surface for the .log-box. Loaded after the table
+// partials so the console surface paint wins by source order.
+@use 'modern-logs';
+
+// Stage R3 (Loop 5): CONTROL CONSISTENCY + SPACING POLISH. Unifies the four
+// filter panels' field labels onto the SAME uppercase muted-grey eyebrow R2 uses
+// in the logs toolbar (resolving the logs-uppercase vs filters-sentence-case
+// inconsistency), pins filter inputs/selects/tags/date-pickers to one shared 34px
+// control height, and aligns the top-bar filter dropdown menus to the same
+// rhythm. Loaded AFTER modern-cards / modern-inputs / modern-logs so the eyebrow
+// label + control-height rules win by source order.
+@use 'modern-controls';
+
+// A11Y PAINT LAYER (Bucket-A, paint-only). Loaded LAST so its AA text colours,
+// focus rings, and reduced-motion / prefers-contrast / forced-colors overrides
+// win the cascade. Markup/ARIA work is deferred to argo-workflows-yu9.
+@use 'a11y-paint';
+
+// Stage 3: fix the floating "Get help" widget's teal-on-teal label. Loaded
+// AFTER a11y-paint so the scoped `.chat-button.argo-button--special` white-label
+// + AA-darkened-fill rule wins by source order as well as by specificity
+// (it must beat the a11y-paint `a:link` teal link colour). Paint-only.
+@use 'modern-help-button';

--- a/ui/src/cron-workflows/cron-workflow-filters.scss
+++ b/ui/src/cron-workflows/cron-workflow-filters.scss
@@ -1,15 +1,16 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
-.wf-filters-container {
-    overflow: visible;
-    position: relative;
-    border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
-    padding: 0 1em 0.75em 1em;
-    margin: 12px 0;
-    background-color: white;
-}
-
+// Filter sidebar — the card SURFACE (overflow / position / margin / background /
+// border / radius / shadow / padding) is the SHARED `.wf-filters-container`
+// definition in app-local _modern-cards.scss (loaded last, wins by source
+// order), so all four filter panels (workflows / cron / templates / reports)
+// stay in lockstep and cannot drift. This file keeps ONLY the page-local layout
+// rhythm not owned by the shared surface.
+//
+// This panel stacks its field groups vertically, so each `p` label group carries
+// a top margin (the workflows-list panel lays its groups out horizontally and
+// therefore does not). Field-label TYPOGRAPHY (the uppercase muted eyebrow on
+// `.wf-filters-container__title`) is owned by _modern-controls.scss.
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
@@ -21,8 +22,6 @@
     position: relative;
     width: 100%;
     max-width: 100%;
-    padding: 8px 0;
-    font-size: 15px;
     background-color: transparent;
     border: 0;
 }

--- a/ui/src/cron-workflows/cron-workflow-list.tsx
+++ b/ui/src/cron-workflows/cron-workflow-list.tsx
@@ -141,17 +141,17 @@ export function CronWorkflowList() {
                             <div className='argo-table-list'>
                                 <div className='row argo-table-list__head'>
                                     <div className='columns small-1' />
-                                    <div className='columns small-2'>NAME</div>
-                                    <div className='columns small-2'>NAMESPACE</div>
-                                    <div className='columns small-1'>TimeZone</div>
-                                    <div className='columns small-1'>SCHEDULES</div>
+                                    <div className='columns small-2'>Name</div>
+                                    <div className='columns small-2'>Namespace</div>
+                                    <div className='columns small-1'>Timezone</div>
+                                    <div className='columns small-1'>Schedules</div>
                                     <div className='columns small-1' />
                                     <div className='columns small-2'>
-                                        CREATED{' '}
+                                        Created{' '}
                                         <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormatCreation} setStoredDisplayISOFormat={setStoredDisplayISOFormatCreation} />
                                     </div>
                                     <div className='columns small-2'>
-                                        NEXT RUN{' '}
+                                        Next run{' '}
                                         <TimestampSwitch
                                             storedDisplayISOFormat={storedDisplayISOFormatNextScheduled}
                                             setStoredDisplayISOFormat={setStoredDisplayISOFormatNextScheduled}

--- a/ui/src/reports/reports-filters.scss
+++ b/ui/src/reports/reports-filters.scss
@@ -1,15 +1,16 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
-.wf-filters-container {
-    overflow: visible;
-    position: relative;
-    border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
-    padding: 0 1em 0.75em 1em;
-    margin: 12px 0;
-    background-color: white;
-}
-
+// Filter sidebar — the card SURFACE (overflow / position / margin / background /
+// border / radius / shadow / padding) is the SHARED `.wf-filters-container`
+// definition in app-local _modern-cards.scss (loaded last, wins by source
+// order), so all four filter panels (workflows / cron / templates / reports)
+// stay in lockstep and cannot drift. This file keeps ONLY the page-local layout
+// rhythm not owned by the shared surface.
+//
+// This panel stacks its field groups vertically, so each `p` label group carries
+// a top margin (the workflows-list panel lays its groups out horizontally and
+// therefore does not). Field-label TYPOGRAPHY (the uppercase muted eyebrow on
+// `.wf-filters-container__title`) is owned by _modern-controls.scss.
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
@@ -21,8 +22,6 @@
     position: relative;
     width: 100%;
     max-width: 100%;
-    padding: 8px 0;
-    font-size: 15px;
     background-color: transparent;
     border: 0;
 }

--- a/ui/src/reports/workflows-to-chart-data.ts
+++ b/ui/src/reports/workflows-to-chart-data.ts
@@ -1,8 +1,15 @@
 import type {AnnotationOptions} from 'chartjs-plugin-annotation';
 
 import {denominator} from '../shared/duration';
-import {getColorForNodePhase, Workflow} from '../shared/models';
+import {Workflow} from '../shared/models';
 import type {Chart} from './reports';
+
+// Neutral/teal duration bar color. Duration is a neutral metric, so it must NOT
+// be colored by workflow phase (which painted every bar the saturated alarm-red
+// of getColorForNodePhase for failed/errored runs, reading as an error for a
+// plain duration). Reuse the same teal accent the CPU resource series uses
+// below (#00a2b3 === --awf-accent), reserving red for actual failure. AA-clean.
+const DURATION_BAR_COLOR = '#00a2b3';
 
 export function workflowsToChartData(workflows: Workflow[], limit: number): Chart[] {
     const filteredWorkflows = workflows
@@ -25,7 +32,7 @@ export function workflowsToChartData(workflows: Workflow[], limit: number): Char
 
     filteredWorkflows.forEach((wf, i) => {
         labels[i] = wf.name;
-        backgroundColors[i] = getColorForNodePhase(wf.phase);
+        backgroundColors[i] = DURATION_BAR_COLOR;
         durationData[i] = (wf.finishedAt.getTime() - wf.startedAt.getTime()) / 1000;
         Object.entries(wf.resourcesDuration || {}).forEach(([resource, value]) => {
             if (!resourceData[resource]) {
@@ -35,10 +42,10 @@ export function workflowsToChartData(workflows: Workflow[], limit: number): Char
         });
     });
     const resourceColors = {
-        'cpu': 'teal',
-        'memory': 'blue',
-        'storage': 'purple',
-        'ephemeral-storage': 'purple'
+        'cpu': '#00a2b3',
+        'memory': '#3576c4',
+        'storage': '#f4c030',
+        'ephemeral-storage': '#806100'
     } as {[resource: string]: string};
 
     const avgDuration = durationData.length > 0 ? durationData.reduce((a, b) => a + b, 0) / durationData.length : 0;
@@ -103,7 +110,7 @@ export function workflowsToChartData(workflows: Workflow[], limit: number): Char
                     yAxisID: resource,
                     label: resource,
                     data,
-                    backgroundColor: resourceColors[resource] || 'black'
+                    backgroundColor: resourceColors[resource] || '#363c4a'
                 }))
             },
             options: {

--- a/ui/src/shared/components/button.tsx
+++ b/ui/src/shared/components/button.tsx
@@ -18,11 +18,7 @@ export const Button = ({
     icon?: Icon;
     className?: string;
 }) => (
-    <button
-        style={{marginBottom: 2, marginRight: 2}}
-        className={'argo-button ' + (!outline ? 'argo-button--base' : 'argo-button--base-o') + ' ' + (className || '')}
-        title={title}
-        onClick={onClick}>
+    <button className={'argo-button awf-btn-spaced ' + (!outline ? 'argo-button--base' : 'argo-button--base-o') + ' ' + (className || '')} title={title} onClick={onClick}>
         {icon && <i className={'fa fa-' + icon} />} {children}
     </button>
 );

--- a/ui/src/shared/components/chat-button.tsx
+++ b/ui/src/shared/components/chat-button.tsx
@@ -23,7 +23,7 @@ export function ChatButton() {
 
     return (
         <div style={{position: 'fixed', right: 10, bottom: 10}}>
-            <a href={link.url} className='argo-button argo-button--special' target='_blank' rel='noreferrer'>
+            <a href={link.url} className='argo-button argo-button--special chat-button' target='_blank' rel='noreferrer'>
                 <i className='fas fa-comment-alt' /> {link.name}
             </a>
         </div>

--- a/ui/src/shared/components/checkbox-filter/checkbox-filter.scss
+++ b/ui/src/shared/components/checkbox-filter/checkbox-filter.scss
@@ -1,24 +1,104 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
+// CheckboxFilter — restyled to Argo CD's status-filter rows (Loop 9, Stage A.2):
+// each row is a rounded 2em line carrying [checkbox][colored status dot][label]
+// [right-aligned count], matching argo-cd `.filter__item`. The Checkbox onChange
+// is untouched (filtering behaviour unchanged); the dot + count are display-only.
+//
+// Grounded in argo-cd ui/src/app/applications/components/filter/filter.scss:
+//   .filter__item { height:2em; padding:0 5px; border-radius:5px; display:flex;
+//                   align-items:center; margin:.15em 0; }
+//   count { margin-left:auto } (right aligned)
 .checkbox-filter {
-    max-height: calc(1.55em * 14);
+    max-height: calc(2em * 14);
     transition: max-height 0.25s cubic-bezier(0, 1, 0, 1);
     overflow-y: auto;
-    margin-left: 0.2rem;
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(100px, 120px));
+    margin: 0;
+    padding: 0;
+    // Single-column vertical list (argo-cd style), not a multi-col chip grid.
+    display: block;
 }
 
 .checkbox-filter li {
     list-style: none;
 }
 
+// Each row -> argo-cd `.filter__item`.
+.checkbox-filter li > .row {
+    height: 2em;
+    margin: 0.15em 0;
+    padding: 0 5px;
+    border-radius: 5px;
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    transition: background-color 0.15s ease;
+
+    &:hover {
+        background-color: var(--awf-ghost-hover, #f0f7f9);
+    }
+}
+
 .checkbox-filter__label {
-    vertical-align: bottom;
-    width: calc(100% - 50px);
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline-block;
     white-space: nowrap;
-    margin-right: 25px;
+
+    label {
+        // Phase labels (Pending/Running/Succeeded/Failed/Error) are short and the
+        // filter card has ample width, so the label sizes to its content and is
+        // never clipped: do NOT shrink it (flex-shrink 0) and drop the
+        // overflow/ellipsis clamp. The count still right-aligns via its own
+        // margin-left:auto, so "Succeeded" + its count both show in full.
+        flex: 0 0 auto;
+        white-space: nowrap;
+        margin: 0;
+        cursor: pointer;
+    }
+}
+
+// Colored status dot (argo-cd renders a fa-circle in the phase colour; we use a
+// simple 8px filled circle keyed off the phase name).
+.checkbox-filter__dot {
+    flex: 0 0 auto;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin: 0 var(--awf-space-2, 8px) 0 var(--awf-space-1, 4px);
+    background: var(--awf-muted, #6d7f8b);
+
+    &--phase-Succeeded {
+        background: var(--awf-status-succeeded-text, #0a7257);
+    }
+    &--phase-Running {
+        background: var(--awf-status-running-text, #0a7299);
+    }
+    &--phase-Pending {
+        background: var(--awf-status-pending-text, #566a78);
+    }
+    &--phase-Failed,
+    &--phase-Error {
+        background: var(--awf-status-failed-text, #be3d47);
+    }
+
+    // Cron-workflow State filter (type='state').
+    &--state-Running {
+        background: var(--awf-status-running-text, #0a7299);
+    }
+    &--state-Suspended {
+        background: var(--awf-status-pending-text, #566a78);
+    }
+}
+
+// Right-aligned count (argo-cd `margin-left:auto`).
+.checkbox-filter__count {
+    margin-left: auto;
+    padding-left: var(--awf-space-2, 8px);
+    flex: 0 0 auto;
+    font-size: var(--awf-font-size-meta, 12px);
+    color: var(--awf-muted-aa, #556472);
+    font-variant-numeric: tabular-nums;
 }

--- a/ui/src/shared/components/checkbox-filter/checkbox-filter.tsx
+++ b/ui/src/shared/components/checkbox-filter/checkbox-filter.tsx
@@ -8,6 +8,11 @@ interface Props {
     type: string;
     selected: string[];
     onChange: (selected: string[]) => void;
+    // Display-only: when true, render the right-aligned per-item count (Argo CD
+    // status-filter style). Off by default so callers whose `count` is not a
+    // meaningful tally (e.g. the cron State filter's placeholder values) do not
+    // surface a misleading number. Does not affect filtering behaviour.
+    showCounts?: boolean;
 }
 
 export function CheckboxFilter(props: Props) {
@@ -35,9 +40,11 @@ export function CheckboxFilter(props: Props) {
                                         props.onChange(newSelected);
                                     }}
                                 />{' '}
+                                <span className={`checkbox-filter__dot checkbox-filter__dot--${props.type} checkbox-filter__dot--${props.type}-${item.name}`} aria-hidden='true' />
                                 <label title={item.name} htmlFor={`filter-${props.type}-${item.name}`}>
                                     {item.name}
                                 </label>
+                                {props.showCounts && <span className='checkbox-filter__count'>{item.count}</span>}
                             </div>
                         </div>
                     </React.Fragment>

--- a/ui/src/shared/components/input-filter.scss
+++ b/ui/src/shared/components/input-filter.scss
@@ -6,5 +6,22 @@
   div:first-child {
     flex: 1;
   }
+
+  // The trailing clear ("x") affordance inherited the teal link colour, which
+  // read as a wrong "green" tick next to the field. A clear/reset control should
+  // be a neutral muted glyph, not an accent colour. Paint only — the <a>'s
+  // clear-on-click behaviour is untouched. (The button is now conditionally
+  // rendered by the component only when the field has a value, so it no longer
+  // shows next to an empty field.)
+  a,
+  a:link,
+  a:visited {
+    color: var(--awf-muted-aa, #556472);
+  }
+
+  a:hover,
+  a:focus {
+    color: var(--awf-text, #495763);
+  }
 }
 

--- a/ui/src/shared/components/input-filter.tsx
+++ b/ui/src/shared/components/input-filter.tsx
@@ -63,13 +63,15 @@ export function InputFilter(props: InputProps) {
                 filterSuggestions={props.filterSuggestions}
                 autoHighlight={props.autoHighlight}
             />
-            <a
-                onClick={() => {
-                    setValue('');
-                    props.onChange('');
-                }}>
-                <i className='fa fa-times-circle' />
-            </a>
+            {value && (
+                <a
+                    onClick={() => {
+                        setValue('');
+                        props.onChange('');
+                    }}>
+                    <i className='fa fa-times-circle' />
+                </a>
+            )}
         </div>
     );
 }

--- a/ui/src/shared/components/namespace-filter.tsx
+++ b/ui/src/shared/components/namespace-filter.tsx
@@ -5,7 +5,7 @@ import {InputFilter} from './input-filter';
 
 export const NamespaceFilter = (props: {value: string; onChange: (namespace: string) => void; extraNamespaces?: string[]}) =>
     nsUtils.getManagedNamespace() ? (
-        <>{nsUtils.getManagedNamespace()}</>
+        <span className='namespace-filter__value'>{nsUtils.getManagedNamespace()}</span>
     ) : (
         <InputFilter value={props.value} name='ns' onChange={ns => props.onChange(ns)} extraSuggestions={props.extraNamespaces} filterSuggestions />
     );

--- a/ui/src/shared/components/pagination-panel.tsx
+++ b/ui/src/shared/components/pagination-panel.tsx
@@ -5,13 +5,13 @@ import {WarningIcon} from './fa-icons';
 
 export function PaginationPanel(props: {pagination: Pagination; onChange: (pagination: Pagination) => void; numRecords: number}) {
     return (
-        <p style={{paddingBottom: '45px'}}>
-            <button disabled={!props.pagination.offset} className='argo-button argo-button--base-o' onClick={() => props.onChange({limit: props.pagination.limit})}>
+        <p className='wf-pagination'>
+            <button disabled={!props.pagination.offset} className='argo-button argo-button--base' onClick={() => props.onChange({limit: props.pagination.limit})}>
                 First page
             </button>
             <button
                 disabled={!props.pagination.nextOffset}
-                className='argo-button argo-button--base-o'
+                className='argo-button argo-button--base'
                 onClick={() =>
                     props.onChange({
                         limit: props.pagination.limit,

--- a/ui/src/shared/components/upload-button.tsx
+++ b/ui/src/shared/components/upload-button.tsx
@@ -13,7 +13,7 @@ export function UploadButton<T>(props: {onUpload: (value: T) => void; onError: (
     }
 
     return (
-        <label style={{marginBottom: 2, marginRight: 2}} className='argo-button argo-button--base-o' key='upload-file'>
+        <label className='argo-button awf-btn-spaced argo-button--base-o' key='upload-file'>
             <input type='file' onChange={e => handleFiles(e.target.files)} style={{display: 'none'}} />
             <i className='fa fa-upload' /> Upload file
         </label>

--- a/ui/src/shared/footnote.tsx
+++ b/ui/src/shared/footnote.tsx
@@ -1,3 +1,3 @@
 import * as React from 'react';
 
-export const Footnote = ({children}: {children: React.ReactNode}) => <p style={{margin: 20}}>{children}</p>;
+export const Footnote = ({children}: {children: React.ReactNode}) => <p className='wf-footnote'>{children}</p>;

--- a/ui/src/shared/models/workflows.ts
+++ b/ui/src/shared/models/workflows.ts
@@ -1025,14 +1025,14 @@ export function getColorForNodePhase(p: NodePhase) {
     switch (p) {
         case NODE_PHASE.ERROR:
         case NODE_PHASE.FAILED:
-            return '#E96D76';
+            return '#be3d47';
         case NODE_PHASE.PENDING:
         case NODE_PHASE.RUNNING:
-            return '#0DADEA';
+            return '#0a7299';
         case NODE_PHASE.SUCCEEDED:
-            return '#18BE94';
+            return '#0a7257';
         default:
-            return '#6D7F8B';
+            return '#6d7f8b';
     }
 }
 

--- a/ui/src/workflow-templates/workflow-template-filters.scss
+++ b/ui/src/workflow-templates/workflow-template-filters.scss
@@ -1,15 +1,16 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
-.wf-filters-container {
-    overflow: visible;
-    position: relative;
-    border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
-    padding: 0 1em 0.75em 1em;
-    margin: 12px 0;
-    background-color: white;
-}
-
+// Filter sidebar — the card SURFACE (overflow / position / margin / background /
+// border / radius / shadow / padding) is the SHARED `.wf-filters-container`
+// definition in app-local _modern-cards.scss (loaded last, wins by source
+// order), so all four filter panels (workflows / cron / templates / reports)
+// stay in lockstep and cannot drift. This file keeps ONLY the page-local layout
+// rhythm not owned by the shared surface.
+//
+// This panel stacks its field groups vertically, so each `p` label group carries
+// a top margin (the workflows-list panel lays its groups out horizontally and
+// therefore does not). Field-label TYPOGRAPHY (the uppercase muted eyebrow on
+// `.wf-filters-container__title`) is owned by _modern-controls.scss.
 .wf-filters-container p {
     margin: 0;
     margin-top: 1em;
@@ -21,8 +22,6 @@
     position: relative;
     width: 100%;
     max-width: 100%;
-    padding: 4px 0;
-    font-size: 15px;
     background-color: transparent;
     border: 0;
 }

--- a/ui/src/workflow-templates/workflow-template-list.tsx
+++ b/ui/src/workflow-templates/workflow-template-list.tsx
@@ -155,10 +155,10 @@ export function WorkflowTemplateList() {
                             <div className='argo-table-list'>
                                 <div className='row argo-table-list__head'>
                                     <div className='columns small-1' />
-                                    <div className='columns small-5'>NAME</div>
-                                    <div className='columns small-3'>NAMESPACE</div>
+                                    <div className='columns small-5'>Name</div>
+                                    <div className='columns small-3'>Namespace</div>
                                     <div className='columns small-3'>
-                                        CREATED <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormat} setStoredDisplayISOFormat={setStoredDisplayISOFormat} />
+                                        Created <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormat} setStoredDisplayISOFormat={setStoredDisplayISOFormat} />
                                     </div>
                                 </div>
                                 {templates.map(t => {

--- a/ui/src/workflows/components/workflow-details-list/workflow-details-list.tsx
+++ b/ui/src/workflows/components/workflow-details-list/workflow-details-list.tsx
@@ -20,19 +20,19 @@ export function WorkflowDetailsList(props: WorkflowDetailsList) {
             <div className='row argo-table-list__head'>
                 <div className='columns small-1 workflows-list__status' />
                 <div className='row small-11'>
-                    <div className='columns small-2'>NAME</div>
-                    <div className='columns small-1'>NAMESPACE</div>
+                    <div className='columns small-2'>Name</div>
+                    <div className='columns small-1'>Namespace</div>
                     <div className='columns small-1'>
-                        STARTED <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormatStart} setStoredDisplayISOFormat={setStoredDisplayISOFormatStart} />
+                        Started <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormatStart} setStoredDisplayISOFormat={setStoredDisplayISOFormatStart} />
                     </div>
                     <div className='columns small-1'>
-                        FINISHED <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormatFinished} setStoredDisplayISOFormat={setStoredDisplayISOFormatFinished} />
+                        Finished <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormatFinished} setStoredDisplayISOFormat={setStoredDisplayISOFormatFinished} />
                     </div>
-                    <div className='columns small-1'>DURATION</div>
-                    <div className='columns small-1'>PROGRESS</div>
-                    <div className='columns small-2'>MESSAGE</div>
-                    <div className='columns small-1'>DETAILS</div>
-                    <div className='columns small-1'>ARCHIVED</div>
+                    <div className='columns small-1'>Duration</div>
+                    <div className='columns small-1'>Progress</div>
+                    <div className='columns small-2'>Message</div>
+                    <div className='columns small-1'>Details</div>
+                    <div className='columns small-1'>Archived</div>
                     {(props.columns || []).map(col => {
                         return (
                             <div className='columns small-1' key={col.key}>

--- a/ui/src/workflows/components/workflow-details/workflow-details.tsx
+++ b/ui/src/workflows/components/workflow-details/workflow-details.tsx
@@ -197,7 +197,7 @@ export function WorkflowDetails() {
             .map(actionName => {
                 const workflowOperation = workflowOperationsMap[actionName];
                 return {
-                    title: workflowOperation.title.charAt(0).toUpperCase() + workflowOperation.title.slice(1),
+                    title: workflowOperation.title.charAt(0).toUpperCase() + workflowOperation.title.slice(1).toLowerCase(),
                     iconClassName: workflowOperation.iconClassName,
                     action: () => {
                         if (workflowOperation.title === 'DELETE') {

--- a/ui/src/workflows/components/workflow-filters/workflow-filters.scss
+++ b/ui/src/workflows/components/workflow-filters/workflow-filters.scss
@@ -1,28 +1,38 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
-.wf-filters-container {
-    overflow: visible;
-    position: relative;
-    border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
-    padding: 0 1em 0.75em 1em;
-    margin: 12px 0;
-    background-color: white;
-}
+// Workflow FILTER panel — restyled toward Argo CD's filters sidebar (Loop 9,
+// Stage A.2). Grounded in argo-cd ui/src/app/applications/components/filter/
+// filter.scss + filters-group (a cohesive FILTERS group of evenly-spaced labeled
+// blocks on one surface). The field LABEL treatment (uppercase 12px muted
+// eyebrow) is owned by _modern-controls.scss and intentionally kept here.
+//
+// The card SURFACE (overflow / position / margin / background / border / radius /
+// shadow / padding) AND the cohesive "Filters" group header are the SHARED
+// `.wf-filters-container` definition in _modern-cards.scss, used by ALL FOUR
+// filter panels so they cannot drift.
+//
+// Loop 11 (item 2): the "Filters" group header was promoted to that shared base
+// so the workflows / cron / templates / reports sidebars all get the identical
+// bordered grouped-card treatment. The workflows-list-only `--workflows::before`
+// header that used to live here was the source of the cross-page inconsistency
+// and has been removed. Inputs/checkboxes are untouched.
 
 .wf-filters-container p {
     margin: 0;
-    margin-top: 1em;
-    color: #6d7f8b;
-    text-transform: uppercase;
+    color: var(--awf-muted-aa, #556472);
+    // Sentence case, no tracking: the uppercase + tracking eyebrow read as
+    // gappy/cheap. The strict label typography is owned by _modern-controls.scss.
+    text-transform: none;
+    letter-spacing: normal;
 }
+
+// (The first-field-snug-under-header trim now lives in the shared
+// _modern-cards.scss `.wf-filters-container` so all four panels share it.)
 
 .wf-filters-container__title {
     position: relative;
     width: 100%;
     max-width: 100%;
-    padding: 8px 0;
-    font-size: 15px;
     background-color: transparent;
     border: 0;
 }
@@ -36,4 +46,22 @@
 
 #top-bar__filter-list {
     column-count: 1;
+}
+
+// The managed-namespace VALUE (e.g. "argo") renders as plain text directly under
+// the "Namespace" label. It must read as a calm FIELD VALUE matching the rest of
+// the sidebar's control text (Name Contains / Labels inputs), not stand out. The
+// control-text rule in _modern-controls.scss (.argo-field/.select__value/…) does
+// not reach this bare span, so without this it inherited a larger/divergent size.
+// Pin it to the shared body font stack, the 14px control text size, normal weight
+// and the primary field-text colour — kept indented 8px under its label. Styling
+// only.
+.wf-filters-container .namespace-filter__value {
+    display: block;
+    padding-left: var(--awf-space-2, 8px);
+    font-family: inherit;
+    font-size: var(--awf-font-size-body, 14px);
+    font-weight: var(--awf-weight-regular, 400);
+    line-height: 1.2;
+    color: var(--awf-text, #495763);
 }

--- a/ui/src/workflows/components/workflow-filters/workflow-filters.tsx
+++ b/ui/src/workflows/components/workflow-filters/workflow-filters.tsx
@@ -95,7 +95,7 @@ export function WorkflowFilters(props: WorkflowFilterProps) {
     }
 
     return (
-        <div className='wf-filters-container'>
+        <div className='wf-filters-container wf-filters-container--workflows'>
             <div className='row'>
                 <div className='columns small-2 xlarge-12'>
                     <p className='wf-filters-container__title'>Namespace</p>
@@ -148,7 +148,7 @@ export function WorkflowFilters(props: WorkflowFilterProps) {
                 </div>
                 <div className='columns small-4 xlarge-12'>
                     <p className='wf-filters-container__title'>Phases</p>
-                    <CheckboxFilter selected={props.phases} onChange={props.setPhases} items={phaseItems} type='phase' />
+                    <CheckboxFilter selected={props.phases} onChange={props.setPhases} items={phaseItems} type='phase' showCounts={true} />
                 </div>
                 <div className='columns small-5 xlarge-12'>
                     <p className='wf-filters-container__title'>Created Since</p>
@@ -161,9 +161,11 @@ export function WorkflowFilters(props: WorkflowFilterProps) {
                             todayButton='Today'
                             className='argo-field argo-textarea'
                         />
-                        <a onClick={() => props.setCreatedAfter(undefined)}>
-                            <i className='fa fa-times-circle' />
-                        </a>
+                        {props.createdAfter && (
+                            <a onClick={() => props.setCreatedAfter(undefined)}>
+                                <i className='fa fa-times-circle' />
+                            </a>
+                        )}
                     </div>
                     <p className='wf-filters-container__title'>Finished Before</p>
                     <div className='wf-filters-container__content'>
@@ -175,9 +177,11 @@ export function WorkflowFilters(props: WorkflowFilterProps) {
                             todayButton='Today'
                             className='argo-field argo-textarea'
                         />
-                        <a onClick={() => props.setFinishedBefore(undefined)}>
-                            <i className='fa fa-times-circle' />
-                        </a>
+                        {props.finishedBefore && (
+                            <a onClick={() => props.setFinishedBefore(undefined)}>
+                                <i className='fa fa-times-circle' />
+                            </a>
+                        )}
                     </div>
                 </div>
             </div>

--- a/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.scss
+++ b/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.scss
@@ -7,15 +7,11 @@
 .log-box {
   min-height: 500px;
   max-height: 800px;
-  padding: 10px;
   margin: 10px;
-  background-color: white;
+  // Console surface treatment (padding / background / border / radius) is owned
+  // by _modern-logs.scss so the Logs view reads as a deliberate terminal.
 }
 
-.log-menu {
-  display: flex;
-  column-gap: 12px;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-}
+// The .log-menu toolbar layout + control styling is owned by _modern-logs.scss
+// so the inputs, labels and the "Log Fields" action share one design language
+// and one baseline (loaded after argo-ui so it wins by source order).

--- a/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
+++ b/ui/src/workflows/components/workflow-logs-viewer/workflow-logs-viewer.tsx
@@ -240,43 +240,55 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
                     <i className='fa fa-exclamation-triangle' /> Logs for archived workflows may be overwritten by a more recent workflow with the same name.
                 </p>
             )}
-            <div style={{marginBottom: 10}}>
-                <i className='fa fa-box' />{' '}
-                <Autocomplete
-                    items={podNames}
-                    value={(podNames.find(x => x.value === podName) || {label: ''}).label}
-                    onSelect={(_, item) => {
-                        setPodName(item.value);
-                    }}
-                />{' '}
-                /{' '}
-                <Autocomplete
-                    items={containers}
-                    value={candidateContainer}
-                    onSelect={v => {
-                        setCandidateContainer(v);
-                        setContainer(v);
-                    }}
-                    onChange={v => setCandidateContainer(v.target.value)}
-                    renderInput={props => (
-                        <input
-                            {...props}
-                            onKeyUp={event => {
-                                if (event.keyCode === 13) {
-                                    // ENTER, to confirm custom container name input
-                                    setContainer(candidateContainer);
-                                }
+            <div className='log-menu'>
+                <div className='log-menu__group'>
+                    <label className='log-menu__field'>
+                        <span className='log-menu__label'>
+                            <i className='fa fa-box' /> Pod
+                        </span>
+                        <Autocomplete
+                            items={podNames}
+                            value={(podNames.find(x => x.value === podName) || {label: ''}).label}
+                            onSelect={(_, item) => {
+                                setPodName(item.value);
                             }}
                         />
-                    )}
-                />
-                <Button onClick={popupJsonFieldSelector} icon={'exchange-alt'}>
-                    Log Fields
-                </Button>
-                <span className='fa-pull-right'>
-                    <div className='log-menu'>
-                        <i className='fa fa-filter' /> <input type='search' defaultValue={grep} onChange={v => setDebouncedGrep(v.target.value)} placeholder='Filter (regexp)...' />
-                        <i className='fa fa-globe' />{' '}
+                    </label>
+                    <label className='log-menu__field'>
+                        <span className='log-menu__label'>Container</span>
+                        <Autocomplete
+                            items={containers}
+                            value={candidateContainer}
+                            onSelect={v => {
+                                setCandidateContainer(v);
+                                setContainer(v);
+                            }}
+                            onChange={v => setCandidateContainer(v.target.value)}
+                            renderInput={props => (
+                                <input
+                                    {...props}
+                                    onKeyUp={event => {
+                                        if (event.keyCode === 13) {
+                                            // ENTER, to confirm custom container name input
+                                            setContainer(candidateContainer);
+                                        }
+                                    }}
+                                />
+                            )}
+                        />
+                    </label>
+                </div>
+                <div className='log-menu__group log-menu__group--end'>
+                    <label className='log-menu__field'>
+                        <span className='log-menu__label'>
+                            <i className='fa fa-filter' /> Filter
+                        </span>
+                        <input className='log-menu__search' type='search' defaultValue={grep} onChange={v => setDebouncedGrep(v.target.value)} placeholder='Filter (regexp)...' />
+                    </label>
+                    <label className='log-menu__field'>
+                        <span className='log-menu__label'>
+                            <i className='fa fa-globe' /> Timezone
+                        </span>
                         <Autocomplete
                             items={filteredTimezones}
                             value={uiTimezone}
@@ -284,8 +296,11 @@ export function WorkflowLogsViewer({workflow, initialNodeId, initialPodName, con
                             // useEffect ensures UITimezone is also changed
                             onSelect={setTimezone}
                         />
-                    </div>
-                </span>
+                    </label>
+                    <Button className='log-menu__action' onClick={popupJsonFieldSelector} icon={'exchange-alt'}>
+                        Log fields
+                    </Button>
+                </div>
             </div>
             <ErrorNotice error={error} />
             {!loaded ? (

--- a/ui/src/workflows/components/workflows-list/workflows-list.scss
+++ b/ui/src/workflows/components/workflows-list/workflows-list.scss
@@ -105,59 +105,6 @@
         }
     }
 
-    &__filters-expander {
-        position: absolute;
-        top: 0.75em;
-        right: 1em;
-        cursor: pointer;
-    }
-
-    &__filters-container {
-        max-height: 2.5em;
-        overflow: hidden;
-        position: relative;
-        border-radius: $border-radius;
-        box-shadow: 1px 1px 3px $argo-color-gray-5;
-        padding: 0 1em 0.75em 1em;
-        margin: 33px 0;
-        background-color: white;
-        transition: max-height 0.25s cubic-bezier(0, 1, 0, 1);
-
-        ul,
-        a,
-        p {
-            margin: 0;
-        }
-
-        p {
-            margin-top: 1em;
-            color: $argo-color-gray-6;
-            text-transform: uppercase;
-        }
-
-        &::before {
-            content: 'FILTERS';
-            display: block;
-            color: $argo-color-gray-6;
-            padding-bottom: 1em;
-            margin-top: 0.5em;
-        }
-
-        &--expanded {
-            overflow-y: auto;
-            max-height: calc(1.55em * 15);
-            transition: max-height 1s ease-in-out;
-            &::before {
-                display: none;
-            }
-        }
-    }
-
-    &__filters-container-title {
-        border-bottom: 1px solid $argo-color-gray-3;
-        margin-bottom: 1em;
-    }
-
     &__filter {
         li {
             list-style: none;

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -291,7 +291,7 @@ export function WorkflowsList() {
                             )}
                             <div className='argo-table-list'>
                                 <div className='row argo-table-list__head'>
-                                    <div className='columns small-1 workflows-list__status'>
+                                    <div className='columns small-2 workflows-list__status'>
                                         <input
                                             type='checkbox'
                                             className='workflows-list__status--checkbox'
@@ -309,28 +309,28 @@ export function WorkflowsList() {
                                             }}
                                         />
                                     </div>
-                                    <div className='row small-11'>
-                                        <div className='columns small-2'>NAME</div>
-                                        <div className='columns small-1'>NAMESPACE</div>
+                                    <div className='row small-10'>
+                                        <div className='columns small-2'>Name</div>
+                                        <div className='columns small-1'>Namespace</div>
                                         <div className='columns small-1'>
-                                            STARTED{' '}
+                                            Started{' '}
                                             <TimestampSwitch storedDisplayISOFormat={storedDisplayISOFormatStart} setStoredDisplayISOFormat={setStoredDisplayISOFormatStart} />
                                         </div>
                                         <div className='columns small-1'>
-                                            FINISHED{' '}
+                                            Finished{' '}
                                             <TimestampSwitch
                                                 storedDisplayISOFormat={storedDisplayISOFormatFinished}
                                                 setStoredDisplayISOFormat={setStoredDisplayISOFormatFinished}
                                             />
                                         </div>
-                                        <div className='columns small-1'>DURATION</div>
-                                        <div className='columns small-1'>PROGRESS</div>
-                                        <div className='columns small-2'>MESSAGE</div>
-                                        <div className='columns small-1'>DETAILS</div>
-                                        <div className='columns small-1'>ARCHIVED</div>
+                                        <div className='columns small-1'>Duration</div>
+                                        <div className='columns small-1'>Progress</div>
+                                        <div className='columns small-2'>Message</div>
+                                        <div className='columns small-1'>Details</div>
+                                        <div className='columns small-1'>Archived</div>
                                         {(columns || []).map(col => {
                                             return (
-                                                <div className='columns small-1' key={col.key}>
+                                                <div className='columns small-1 workflows-list__custom-col' key={col.key}>
                                                     {col.name}
                                                 </div>
                                             );
@@ -381,7 +381,7 @@ export function WorkflowsList() {
                     )}
                 </div>
             </div>
-            <SlidingPanel isShown={!!sidePanel} onClose={() => setSidePanel('')}>
+            <SlidingPanel isMiddle={true} isShown={!!sidePanel} onClose={() => setSidePanel('')}>
                 {sidePanel === 'submit-new-workflow' && (
                     <WorkflowCreator
                         namespace={nsUtils.getNamespaceWithDefault(namespace)}

--- a/ui/src/workflows/components/workflows-row/workflows-row.tsx
+++ b/ui/src/workflows/components/workflows-row/workflows-row.tsx
@@ -39,7 +39,7 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
     return (
         <div className='workflows-list__row-container'>
             <div className='row argo-table-list__row'>
-                <div className='columns small-1 workflows-list__status'>
+                <div className='columns small-2 workflows-list__status'>
                     <input
                         type='checkbox'
                         className='workflows-list__status--checkbox'
@@ -51,9 +51,11 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                             props.select(props.workflow);
                         }}
                     />
-                    <PhaseIcon value={wf.status.phase} />
+                    <span className={'wf-phase-pill wf-phase-pill--' + (wf.status.phase || 'Unknown')}>
+                        <PhaseIcon value={wf.status.phase} /> {wf.status.phase || 'Unknown'}
+                    </span>
                 </div>
-                <div className='small-11 row'>
+                <div className='small-10 row'>
                     <Link
                         to={{
                             pathname: uiUrl(`workflows/${wf.metadata.namespace}/${wf.metadata.name}`),
@@ -64,17 +66,17 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                             <SuspenseReactMarkdownGfm markdown={markdown} />
                         </div>
                     </Link>
-                    <div className='columns small-1'>{wf.metadata.namespace}</div>
-                    <div className={`columns small-1 ${props.displayISOFormatStart ? 'workflows-list__timestamp' : ''}`}>
+                    <div className='columns small-1 workflows-list__meta'>{wf.metadata.namespace}</div>
+                    <div className={`columns small-1 workflows-list__meta ${props.displayISOFormatStart ? 'workflows-list__timestamp' : ''}`}>
                         <Timestamp date={wf.status.startedAt} displayISOFormat={props.displayISOFormatStart} />
                     </div>
-                    <div className={`columns small-1 ${props.displayISOFormatFinished ? 'workflows-list__timestamp' : ''}`}>
+                    <div className={`columns small-1 workflows-list__meta ${props.displayISOFormatFinished ? 'workflows-list__timestamp' : ''}`}>
                         <Timestamp date={wf.status.finishedAt} displayISOFormat={props.displayISOFormatFinished} />
                     </div>
-                    <div className='columns small-1'>
+                    <div className='columns small-1 workflows-list__meta'>
                         <Ticker>{() => <DurationPanel phase={wf.status.phase} duration={wfDuration(wf.status)} estimatedDuration={wf.status.estimatedDuration} />}</Ticker>
                     </div>
-                    <div className='columns small-1'>{wf.status.progress || '-'}</div>
+                    <div className='columns small-1 workflows-list__meta'>{wf.status.progress || '-'}</div>
                     {/* CSS has text-overflow, but sometimes it's still too long for the column for some reason, so slice it too. 180 chars are not visible on a 4k screen */}
                     <div className='columns small-2'>{wf.status.message?.slice(0, 180) || '-'}</div>
                     <div className='columns small-1'>
@@ -87,11 +89,11 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                                 className={`workflows-row__action workflows-row__action--${hideDrawer ? 'show' : 'hide'}`}>
                                 {hideDrawer ? (
                                     <span>
-                                        SHOW <i className='fas fa-caret-down' />{' '}
+                                        Show <i className='fas fa-caret-down' />{' '}
                                     </span>
                                 ) : (
                                     <span>
-                                        HIDE <i className='fas fa-caret-up' />
+                                        Hide <i className='fas fa-caret-up' />
                                     </span>
                                 )}
                             </div>
@@ -102,7 +104,7 @@ export function WorkflowsRow(props: WorkflowsRowProps) {
                         // best not to make any assumptions and wait until this data is filled
                         const value = (column.type === 'label' ? wf?.metadata?.labels?.[column.key] : wf?.metadata?.annotations?.[column.key]) ?? 'unknown';
                         return (
-                            <div key={column.name} className='columns small-1'>
+                            <div key={column.name} className='columns small-1 workflows-list__custom-col'>
                                 {value}
                             </div>
                         );

--- a/ui/src/workflows/components/workflows-summary-container/workflows-summary-container.scss
+++ b/ui/src/workflows/components/workflows-summary-container/workflows-summary-container.scss
@@ -1,45 +1,146 @@
 @import 'node_modules/argo-ui/src/styles/config';
 
+// WORKFLOWS SUMMARY widget — redesigned as a clean aligned stat block on the
+// shared card/surface system (Loop 9, Stage A.1).
+//
+// WHY THE REDESIGN: the old box used three SEPARATE Foundation `.row` grids, so
+// the four phase cells never shared one column track set (Pending|Succeeded and
+// Failed|Error sized independently, leaving ragged vertical seams and the
+// "Succeeded" value wrapping to its own line). The values were also uncolored
+// and the box wore a legacy non-token shadow.
+//
+// FIX (paint/layout only; markup is className-only):
+//   • Card surface system (token border + radius + no legacy shadow, 16px pad).
+//   • Flatten ALL phase cells onto ONE shared 2-col grid by making the legacy
+//     `.row` wrappers `display:contents` so their child `.columns` become direct
+//     grid items in a single track set — all four phase values align on one
+//     right edge with no wrapping.
+//   • Clear hierarchy: big Running number vs small status-colored phase counts.
+//
+// Sass hygiene: var() tokens; no darken()/lighten().
 .wf-summary-container {
-    color:  $argo-color-gray-6;
-    padding: 5px 0px;
-    overflow: visible;
+    color: $argo-color-gray-7;
     position: relative;
-    border-radius: 5px;
-    box-shadow: 1px 1px 3px #8fa4b1;
-    padding: 0 1em 0.75em 1em;
-    margin: 12px 0;
-    background-color: white;
+    margin: var(--awf-space-3, 12px) 0;
+
+    // Card surface system (replaces the legacy 1px 1px 3px #8fa4b1 shadow).
+    background: var(--awf-surface, #fff);
+    border: 1px solid var(--awf-hairline, #ccd6dd);
+    border-radius: var(--awf-radius-card, 8px);
+    box-shadow: none;
+    padding: var(--awf-space-4, 16px);
+
+    // Plain block stack (NOT a grid): the legacy Foundation `.row`/`.columns`
+    // markup is laid out as one clean single-column list of full-width rows that
+    // mirrors the Phases filter list below it — each row reads
+    // "label …………… count" with the count right-aligned at the card's inner
+    // gutter (never touching the border). A deterministic flex/block stack avoids
+    // the grid-track width ambiguity that left the counts bunched mid-card.
+    display: block;
 
     &__title {
+        // Eyebrow header on the 8px rhythm.
         width: 100%;
         max-width: 100%;
-        padding: 8px 0;
-        font-size: 15px;
+        margin: 0 0 var(--awf-space-1, 4px);
+        padding: 0;
+        // Match the filter sidebar's section-label treatment exactly so the whole
+        // left rail reads as one calm system: 12px / 600 / no tracking / sentence
+        // case (was uppercase + 0.04em, the "spaced out" eyebrow).
+        font-size: var(--awf-font-size-label, 12px);
+        font-weight: var(--awf-weight-semibold, 600);
+        letter-spacing: normal;
+        line-height: 1.2;
         background-color: transparent;
         border: 0;
-        margin: 0;
-        margin-top: 1em;
-        color: #6d7f8b;
-        text-transform: uppercase;
+        color: var(--awf-heading, #363c4a);
+        text-transform: none;
+
+        i {
+            color: var(--awf-muted, #6d7f8b);
+        }
     }
 
-    &__text{
-        font-size: 16px;
+    // Each legacy `.row` is just a transparent block wrapper now (no float, no
+    // gutter) so its `.columns` children stack as full-width list rows.
+    .row {
+        display: block;
+        margin: 0;
+    }
+
+    // Each phase cell is a full-width flex row: "label …………… count". The
+    // !important defeats Foundation's `.columns.xlarge-6 { width:50% }` so every
+    // row spans the full card width and space-between pins the count to the
+    // card's inner right gutter — all four counts share ONE clean right edge.
+    &.wf-summary-container .row .columns {
+        box-sizing: border-box;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--awf-space-2, 8px);
+        white-space: nowrap;
+        // Foundation's `.xlarge-6` caps these at `flex:0 0 50%; max-width:50%`,
+        // which (not the width) is what kept the rows half-width and the counts
+        // bunched mid-card. Override all three so each row spans the full width.
+        width: 100% !important;
+        max-width: 100% !important;
+        flex: 0 0 100%;
+        min-width: 0;
+        float: none;
+        // Comfortable 4px row rhythm; small right inset keeps the count off the
+        // card border (mirrors the Phases filter rows' breathing room).
+        margin: 0 0 var(--awf-space-1, 4px);
+        padding: 0 var(--awf-space-1, 4px) 0 0;
+        font-variant-numeric: tabular-nums;
+    }
+
+    // The "Running workflows" headline reads as the lead stat — value sits right
+    // next to its label (NOT justified to the far edge like the phase rows), and
+    // a hairline below separates the hero from the phase list so the hierarchy
+    // is unmistakable.
+    &.wf-summary-container .row .columns.xlarge-12 {
+        justify-content: flex-start;
+        gap: var(--awf-space-2, 8px);
+        margin-bottom: var(--awf-space-3, 12px);
+        padding-bottom: var(--awf-space-3, 12px);
+        border-bottom: 1px solid var(--awf-hairline, #ccd6dd);
+    }
+
+    &__text {
+        font-size: var(--awf-font-size-body, 14px);
+        color: var(--awf-text, #495763);
     }
 
     &__subtext {
-        font-size: 12px;
+        font-size: var(--awf-font-size-sm, 13px);
+        color: var(--awf-muted-aa, #556472);
     }
 
+    // Lead "Running" stat — prominent but not oversized: a clean headline count
+    // that reads with its label, sized close to the body text around it.
     &__running {
-        font-size: 16px;
-        font-weight: bold;
-        color: #0DADEA;
+        font-size: var(--awf-font-size-h-sm, 16px);
+        font-weight: var(--awf-weight-semibold, 600);
+        color: var(--awf-status-running-text, #0a7299);
     }
 
+    // Phase counts — small, semibold, each in its own status colour.
     &__others {
-        font-size: 12px;
-        font-weight: bold;
+        font-size: var(--awf-font-size-sm, 13px);
+        font-weight: var(--awf-weight-semibold, 600);
+        color: var(--awf-heading, #363c4a);
+
+        &--pending {
+            color: var(--awf-status-pending-text, #566a78);
+        }
+
+        &--succeeded {
+            color: var(--awf-status-succeeded-text, #0a7257);
+        }
+
+        &--failed,
+        &--error {
+            color: var(--awf-status-failed-text, #be3d47);
+        }
     }
 }

--- a/ui/src/workflows/components/workflows-summary-container/workflows-summary-container.tsx
+++ b/ui/src/workflows/components/workflows-summary-container/workflows-summary-container.tsx
@@ -36,21 +36,21 @@ export function WorkflowsSummaryContainer(props: {workflows: Workflow[]}) {
             <div className='row'>
                 <div className='columns small-12 xlarge-6'>
                     <span className='wf-summary-container__subtext'>Pending &nbsp;</span>
-                    <span className='wf-summary-container__others'>{wfSummary && wfSummary.Pending ? wfSummary.Pending : 0}</span>
+                    <span className='wf-summary-container__others wf-summary-container__others--pending'>{wfSummary && wfSummary.Pending ? wfSummary.Pending : 0}</span>
                 </div>
                 <div className='columns small-12 xlarge-6'>
                     <span className='wf-summary-container__subtext'>Succeeded &nbsp;</span>
-                    <span className='wf-summary-container__others'>{wfSummary && wfSummary.Succeeded ? wfSummary.Succeeded : 0}</span>
+                    <span className='wf-summary-container__others wf-summary-container__others--succeeded'>{wfSummary && wfSummary.Succeeded ? wfSummary.Succeeded : 0}</span>
                 </div>
             </div>
             <div className='row'>
                 <div className='columns small-12 xlarge-6'>
                     <span className='wf-summary-container__subtext'>Failed &nbsp;</span>
-                    <span className='wf-summary-container__others'>{wfSummary && wfSummary.Failed ? wfSummary.Failed : 0}</span>
+                    <span className='wf-summary-container__others wf-summary-container__others--failed'>{wfSummary && wfSummary.Failed ? wfSummary.Failed : 0}</span>
                 </div>
                 <div className='columns small-12 xlarge-6'>
                     <span className='wf-summary-container__subtext'>Error &nbsp;</span>
-                    <span className='wf-summary-container__others'>{wfSummary && wfSummary.Error ? wfSummary.Error : 0}</span>
+                    <span className='wf-summary-container__others wf-summary-container__others--error'>{wfSummary && wfSummary.Error ? wfSummary.Error : 0}</span>
                 </div>
             </div>
         </div>

--- a/ui/src/workflows/components/workflows-toolbar/workflows-toolbar.tsx
+++ b/ui/src/workflows/components/workflows-toolbar/workflows-toolbar.tsx
@@ -120,7 +120,7 @@ export function WorkflowsToolbar(props: WorkflowsToolbarProps) {
                             className={`workflows-toolbar__actions--${operation.title} workflows-toolbar__actions--action`}
                             disabled={numberSelected === 0 || operation.isDisabled}>
                             <i className={operation.iconClassName} />
-                            &nbsp;{operation.title}
+                            &nbsp;{operation.title.charAt(0).toUpperCase() + operation.title.slice(1).toLowerCase()}
                         </button>
                     );
                 })}


### PR DESCRIPTION
<!-- Does this PR fix an issue -->

### Motivation

The Argo Workflows UI styling has drifted and looks dated next to Argo CD, which shares the same underlying component library. This PR modernises the Workflows UI to align with the Argo CD design language, giving the two consoles a consistent, polished feel. It is the **baseline** of a 3-part stack (this restyle → right-hand collapsible filter sidebar → optional dark mode), stacked on top of #16159.

### Modifications

Styling and surgical markup only — **no functional/behavioural changes**:

- Navy left nav rail with the orange Argo logo and version
- Neutral, consistent button system across the app
- Argo CD-style filter sidebar with status-dot filters and a tidy summary box
- Courier-style log console
- Theme tokens, WCAG AA contrast, and `:focus-visible` keyboard focus rings throughout

**Workflows list:**

![Workflows list — restyle baseline](https://raw.githubusercontent.com/tico24/argo-workflows/pr-assets/prs/prA-restyle__workflows-list.png)

### Verification

- `yarn build`, `yarn test`, and `yarn lint` all pass
- Verified against a live backend; no functional or layout regressions — styling and surgical markup only

### Documentation

No documentation changes required — this is a visual restyle with no new user-facing features or configuration.

### AI

Generative AI was used to help prepare this PR (code, commit messages, and description), under human direction, review, and testing.
