### PR TITLE
feat(ui): move filter sidebar to the right with a collapsible, persisted panel

### DIFF
--- a/.features/pending/ui-filter-sidebar-right.md
+++ b/.features/pending/ui-filter-sidebar-right.md
@@ -1,0 +1,6 @@
+Description: Move the filter sidebar to the right and make it collapsible
+Authors: [Tim Collins](https://github.com/tico24)
+Component: General
+Issues: TODO
+
+The filter panel sits on the left and eats horizontal space, so the table gets cramped and truncates columns. This moves it to the right and lets you collapse it to get that width back when you don't need filters open. Done with CSS order rather than reordering the DOM, and the collapsed state is remembered. Applies to the workflows, cron workflows, templates, and reports views.

--- a/ui/src/assets/scss/_modern-filters-layout.scss
+++ b/ui/src/assets/scss/_modern-filters-layout.scss
@@ -1,0 +1,172 @@
+// _modern-filters-layout.scss — FEATURE: right-hand, collapsible filter sidebar.
+//
+// All four list views (workflows / cron / templates / reports) lay out a
+// Foundation `.row` with exactly two PAGE-LEVEL columns:
+//   .columns.small-12.xlarge-2   -> the filter sidebar card
+//   .columns.small-12.xlarge-10  -> the table / charts
+// Foundation's flex grid means DOM order == visual order, so we flip the
+// VISUAL order with `order` (NOT a DOM/JSX reorder, NOT row-reverse) so that:
+//   - all existing tests + filter wiring stay byte-identical, and
+//   - the `.row > .columns:first-child .wf-filters-container__title` margin
+//     trim in _modern-cards.scss keeps matching (DOM first child unchanged).
+//
+// SCOPING: every filter PANEL has its OWN nested `.row > .columns` sub-blocks,
+// so we ONLY ever use DIRECT-CHILD selectors (`> .columns`) to avoid
+// scrambling those nested rows.
+//
+// RESPONSIVE: only applies at xlarge (>= 1200px, argo-ui config) where the two
+// columns sit side-by-side. Below that they are small-12 (100%) and stack —
+// we leave that natural order alone.
+
+// Shared wrapper class added to the four page-level rows.
+.wf-list-layout {
+    // The expand handle is positioned relative to the row when collapsed; the
+    // filter column is the positioning context for the expanded toggle.
+    position: relative;
+
+    > .columns.xlarge-2 {
+        position: relative;
+    }
+
+    @media (min-width: 1200px) {
+        // Move the filter sidebar to the RIGHT, table to the LEFT.
+        > .columns.xlarge-2 {
+            order: 2;
+            // Smooth the collapse: animate the card out to the right.
+            transition: opacity 0.18s ease, transform 0.18s ease;
+        }
+        > .columns.xlarge-10 {
+            order: 1;
+            transition: flex-basis 0.2s ease, max-width 0.2s ease;
+        }
+    }
+
+    // --- Collapsed state -------------------------------------------------
+    &.wf-list-layout--collapsed {
+        @media (min-width: 1200px) {
+            > .columns.xlarge-2 {
+                // Hide the filter card; table reclaims the full width.
+                display: none;
+            }
+            > .columns.xlarge-10 {
+                flex: 0 0 100%;
+                max-width: 100%;
+            }
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        > .columns.xlarge-2,
+        > .columns.xlarge-10 {
+            transition: none;
+        }
+    }
+}
+
+// --- The collapse / expand affordance -----------------------------------
+// ONE neutral control system shared by both states. No teal FILL anywhere —
+// neutral surfaces + hairline borders matching the app's grey button system;
+// teal appears only as a quiet hover accent (icon + border tint). Both states
+// only render at xlarge (>= 1200px) where the sidebar sits beside the table and
+// collapsing is meaningful; below that the columns stack and collapse is a
+// no-op, so showing a handle would orphan it.
+.filters-collapse-toggle {
+    appearance: none;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    font-family: inherit;
+    color: var(--awf-muted-aa);
+    transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+
+    @media (min-width: 1200px) {
+        display: inline-flex;
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--awf-focus-ring);
+        outline-offset: 2px;
+    }
+
+    // EXPANDED state: a compact, ANCHORED neutral icon button docked at the
+    // TOP-RIGHT of the filter rail. It rests as a real neutral chip (surface +
+    // hairline border, matching the card/button system) so it reads as a
+    // deliberate docked control rather than a floating orphan chevron; on
+    // hover/focus the border + icon pick up the quiet teal accent. Absolute
+    // (not float) so it never disturbs the card flow.
+    position: absolute;
+    top: var(--awf-space-2);
+    right: var(--awf-space-2);
+    z-index: 2;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: var(--awf-surface);
+    border: 1px solid var(--awf-hairline);
+    border-radius: var(--awf-radius-control);
+    box-shadow: var(--awf-shadow-card);
+
+    &:hover {
+        color: var(--awf-link-aa);
+        background: var(--awf-ghost-hover);
+        border-color: var(--awf-accent);
+    }
+
+    i {
+        font-size: 14px;
+        line-height: 1;
+    }
+}
+
+// COLLAPSED state: a tasteful NEUTRAL panel-edge handle tucked against the right
+// edge of the now full-width table — a deliberate "pull filters back" tab, not
+// leftover chrome. Neutral surface + hairline border (matching cards/buttons),
+// a filter glyph over a quiet vertical "Filters" label and a small chevron hint.
+// Rounded LEFT edge + soft shadow so it reads as a tab pulled in from the edge;
+// teal only tints the icon/label/border on hover.
+.filters-collapse-toggle--collapsed {
+    position: absolute;
+    top: var(--awf-space-7);
+    right: 0;
+    z-index: 3;
+    width: 32px;
+    height: auto;
+    flex-direction: column;
+    gap: var(--awf-space-2);
+    padding: var(--awf-space-3) var(--awf-space-1);
+    color: var(--awf-muted-aa);
+    background: var(--awf-surface);
+    border: 1px solid var(--awf-hairline);
+    border-right: none;
+    border-radius: var(--awf-radius-card) 0 0 var(--awf-radius-card);
+    box-shadow: var(--awf-shadow-card-hover);
+
+    &:hover {
+        color: var(--awf-link-aa);
+        background: var(--awf-ghost-hover);
+        border-color: var(--awf-accent);
+        border-right: none;
+    }
+
+    .filters-collapse-toggle__glyph {
+        font-size: 14px;
+        line-height: 1;
+        color: var(--awf-link-aa);
+    }
+
+    .filters-collapse-toggle__label {
+        writing-mode: vertical-rl;
+        font-size: var(--awf-font-size-label);
+        font-weight: var(--awf-weight-semibold, 600);
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--awf-heading);
+    }
+
+    .filters-collapse-toggle__chevron {
+        font-size: 12px;
+        line-height: 1;
+        color: var(--awf-muted-aa);
+    }
+}

--- a/ui/src/assets/scss/app-restyle.scss
+++ b/ui/src/assets/scss/app-restyle.scss
@@ -83,3 +83,11 @@
 // + AA-darkened-fill rule wins by source order as well as by specificity
 // (it must beat the a11y-paint `a:link` teal link colour). Paint-only.
 @use 'modern-help-button';
+
+// FEATURE: right-hand, collapsible filter sidebar. Flips the page-level
+// filter/table columns so the filters sit on the RIGHT and the table reclaims
+// the left, plus a persisted collapse-to-the-edge state. Loaded last (layout
+// only, no colour math) so its `order` / collapsed-width rules win by source
+// order. Scoped to the page-level row via `.wf-list-layout > .columns` direct
+// children so nested filter rows are never reordered.
+@use 'modern-filters-layout';

--- a/ui/src/cron-workflows/cron-workflow-list.tsx
+++ b/ui/src/cron-workflows/cron-workflow-list.tsx
@@ -8,6 +8,7 @@ import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {ExampleManifests} from '../shared/components/example-manifests';
 import {InfoIcon} from '../shared/components/fa-icons';
+import {FiltersCollapseToggle} from '../shared/components/filters-collapse-toggle';
 import {Loading} from '../shared/components/loading';
 import {TimestampSwitch} from '../shared/components/timestamp';
 import {ZeroState} from '../shared/components/zero-state';
@@ -18,6 +19,7 @@ import {CronWorkflow} from '../shared/models';
 import * as nsUtils from '../shared/namespaces';
 import {services} from '../shared/services';
 import {useCollectEvent} from '../shared/use-collect-event';
+import {useFiltersCollapsed} from '../shared/use-filters-collapsed';
 import {useQueryParams} from '../shared/use-query-params';
 import useTimestamp, {TIMESTAMP_KEYS} from '../shared/use-timestamp';
 import {CronWorkflowCreator} from './cron-workflow-creator';
@@ -41,6 +43,7 @@ export function CronWorkflowList() {
 
     // state for URL, query, and label parameters
     const isFirstRender = useRef(true);
+    const [filtersCollapsed, toggleFiltersCollapsed] = useFiltersCollapsed();
     const [namespace, setNamespace] = useState<string>(nsUtils.getNamespace(routeParams.namespace) || '');
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel') === 'true');
     const [labels, setLabels] = useState<string[]>([]);
@@ -109,8 +112,9 @@ export function CronWorkflowList() {
                     ]
                 }
             }}>
-            <div className='row'>
+            <div className={`row wf-list-layout ${filtersCollapsed ? 'wf-list-layout--collapsed' : ''}`}>
                 <div className='columns small-12 xlarge-2'>
+                    <FiltersCollapseToggle collapsed={false} onToggle={toggleFiltersCollapsed} />
                     <div>
                         <CronWorkflowFilters
                             cronWorkflows={cronWorkflows || []}
@@ -176,6 +180,7 @@ export function CronWorkflowList() {
                         </>
                     )}
                 </div>
+                {filtersCollapsed && <FiltersCollapseToggle collapsed={true} onToggle={toggleFiltersCollapsed} />}
             </div>
             <SlidingPanel isShown={sidePanel} onClose={() => setSidePanel(false)}>
                 <CronWorkflowCreator namespace={namespace} onCreate={wf => navigation.goto(uiUrl(`cron-workflows/${wf.metadata.namespace}/${wf.metadata.name}`))} />

--- a/ui/src/reports/reports.tsx
+++ b/ui/src/reports/reports.tsx
@@ -9,6 +9,7 @@ import {useLocation, useNavigate, useParams} from 'react-router-dom';
 import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {InfoIcon} from '../shared/components/fa-icons';
+import {FiltersCollapseToggle} from '../shared/components/filters-collapse-toggle';
 import {ZeroState} from '../shared/components/zero-state';
 import {Context} from '../shared/context';
 import {Footnote} from '../shared/footnote';
@@ -16,6 +17,7 @@ import {historyUrl} from '../shared/history';
 import * as nsUtils from '../shared/namespaces';
 import {services} from '../shared/services';
 import {useCollectEvent} from '../shared/use-collect-event';
+import {useFiltersCollapsed} from '../shared/use-filters-collapsed';
 import {ReportFilters} from './reports-filters';
 import {workflowsToChartData} from './workflows-to-chart-data';
 
@@ -39,6 +41,7 @@ export function Reports() {
 
     // state for URL, query, and label parameters
     const isFirstRender = useRef(true);
+    const [filtersCollapsed, toggleFiltersCollapsed] = useFiltersCollapsed();
     const [namespace, setNamespace] = useState<string>(nsUtils.getNamespace(routeParams.namespace) || '');
     const [labels, setLabels] = useState((queryParams.get('labels') || '').split(',').filter(v => v !== ''));
     // internal state
@@ -95,8 +98,9 @@ export function Reports() {
                     {title: namespace, path: uiUrl('reports/' + namespace)}
                 ]
             }}>
-            <div className='row'>
+            <div className={`row wf-list-layout ${filtersCollapsed ? 'wf-list-layout--collapsed' : ''}`}>
                 <div className='columns small-12 xlarge-2'>
+                    <FiltersCollapseToggle collapsed={false} onToggle={toggleFiltersCollapsed} />
                     <ReportFilters namespace={namespace} labels={labels} onChange={onChange} />
                 </div>
                 <div className='columns small-12 xlarge-10'>
@@ -146,6 +150,7 @@ export function Reports() {
                         </>
                     )}
                 </div>
+                {filtersCollapsed && <FiltersCollapseToggle collapsed={true} onToggle={toggleFiltersCollapsed} />}
             </div>
         </Page>
     );

--- a/ui/src/shared/components/filters-collapse-toggle.test.tsx
+++ b/ui/src/shared/components/filters-collapse-toggle.test.tsx
@@ -1,0 +1,27 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {FiltersCollapseToggle} from './filters-collapse-toggle';
+
+describe('FiltersCollapseToggle', () => {
+    it('renders the expanded (collapse) affordance and fires onToggle', () => {
+        const onToggle = jest.fn();
+        render(<FiltersCollapseToggle collapsed={false} onToggle={onToggle} />);
+        const button = screen.getByRole('button', {name: 'Collapse filters'});
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.click(button);
+        expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the collapsed (show) handle with a label and fires onToggle', () => {
+        const onToggle = jest.fn();
+        render(<FiltersCollapseToggle collapsed={true} onToggle={onToggle} />);
+        const button = screen.getByRole('button', {name: 'Show filters'});
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.getByText('Filters')).toBeInTheDocument();
+        fireEvent.click(button);
+        expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+});

--- a/ui/src/shared/components/filters-collapse-toggle.tsx
+++ b/ui/src/shared/components/filters-collapse-toggle.tsx
@@ -1,0 +1,42 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+interface FiltersCollapseToggleProps {
+    collapsed: boolean;
+    onToggle: () => void;
+}
+
+// FiltersCollapseToggle renders the affordance that collapses / expands the
+// (right-hand) filter sidebar. It is shared by all four list views
+// (workflows / cron / templates / reports) so the behaviour and the markup
+// stay identical and a single test covers them all.
+//
+// One NEUTRAL control system, two states (no teal fill — see _modern-filters-layout.scss):
+//  - expanded: a compact, anchored ghost icon button capping the top-right of
+//    the filter panel. A "collapse panel to the right" double-chevron (»)
+//    reads as "push the panel away to the edge".
+//  - collapsed: a tasteful neutral panel-edge handle tucked against the right
+//    edge of the now full-width table — a filter glyph over a quiet vertical
+//    "Filters" label, with a left-pointing double-chevron hint, so it reads as
+//    a deliberate "pull the filters back" tab rather than leftover chrome.
+export function FiltersCollapseToggle({collapsed, onToggle}: FiltersCollapseToggleProps) {
+    return (
+        <button
+            type='button'
+            className={classNames('filters-collapse-toggle', {'filters-collapse-toggle--collapsed': collapsed})}
+            onClick={onToggle}
+            aria-expanded={!collapsed}
+            aria-label={collapsed ? 'Show filters' : 'Collapse filters'}
+            title={collapsed ? 'Show filters' : 'Collapse filters'}>
+            {collapsed ? (
+                <>
+                    <i className='fa fa-filter filters-collapse-toggle__glyph' aria-hidden='true' />
+                    <span className='filters-collapse-toggle__label'>Filters</span>
+                    <i className='fa fa-angle-double-left filters-collapse-toggle__chevron' aria-hidden='true' />
+                </>
+            ) : (
+                <i className='fa fa-angle-double-right' aria-hidden='true' />
+            )}
+        </button>
+    );
+}

--- a/ui/src/shared/use-filters-collapsed.ts
+++ b/ui/src/shared/use-filters-collapsed.ts
@@ -1,0 +1,13 @@
+import {useLocalStorage} from './use-local-storage';
+
+// ONE shared localStorage key so the filter-sidebar collapsed preference
+// follows the user across all four list views (workflows / cron / templates /
+// reports). Default is `false` (expanded) so the baseline look is preserved on
+// first load — zero regression for existing users.
+export const FILTERS_COLLAPSED_KEY = 'filtersCollapsed';
+
+export function useFiltersCollapsed(): [boolean, () => void] {
+    const [collapsed, setCollapsed] = useLocalStorage<boolean>(FILTERS_COLLAPSED_KEY, false);
+    const toggle = () => setCollapsed(!collapsed);
+    return [collapsed, toggle];
+}

--- a/ui/src/workflow-templates/workflow-template-list.tsx
+++ b/ui/src/workflow-templates/workflow-template-list.tsx
@@ -8,6 +8,7 @@ import {uiUrl} from '../shared/base';
 import {ErrorNotice} from '../shared/components/error-notice';
 import {ExampleManifests} from '../shared/components/example-manifests';
 import {InfoIcon} from '../shared/components/fa-icons';
+import {FiltersCollapseToggle} from '../shared/components/filters-collapse-toggle';
 import {Loading} from '../shared/components/loading';
 import {PaginationPanel} from '../shared/components/pagination-panel';
 import {TimestampSwitch} from '../shared/components/timestamp';
@@ -21,6 +22,7 @@ import {Pagination, parseLimit} from '../shared/pagination';
 import {ScopedLocalStorage} from '../shared/scoped-local-storage';
 import {services} from '../shared/services';
 import {useCollectEvent} from '../shared/use-collect-event';
+import {useFiltersCollapsed} from '../shared/use-filters-collapsed';
 import {useQueryParams} from '../shared/use-query-params';
 import useTimestamp, {TIMESTAMP_KEYS} from '../shared/use-timestamp';
 import {WorkflowTemplateCreator} from './workflow-template-creator';
@@ -48,6 +50,7 @@ export function WorkflowTemplateList() {
     const savedOptions = storage.getItem('paginationLimit', 0);
 
     // state for URL and query parameters
+    const [filtersCollapsed, toggleFiltersCollapsed] = useFiltersCollapsed();
     const [namespace, setNamespace] = useState(nsUtils.getNamespace(routeParams.namespace) || '');
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel') === 'true');
     const [namePattern, setNamePattern] = useState('');
@@ -122,8 +125,9 @@ export function WorkflowTemplateList() {
                     ]
                 }
             }}>
-            <div className='row'>
+            <div className={`row wf-list-layout ${filtersCollapsed ? 'wf-list-layout--collapsed' : ''}`}>
                 <div className='columns small-12 xlarge-2'>
+                    <FiltersCollapseToggle collapsed={false} onToggle={toggleFiltersCollapsed} />
                     <div>
                         <WorkflowTemplateFilters
                             templates={templates || []}
@@ -172,6 +176,7 @@ export function WorkflowTemplateList() {
                         </>
                     )}
                 </div>
+                {filtersCollapsed && <FiltersCollapseToggle collapsed={true} onToggle={toggleFiltersCollapsed} />}
             </div>
             <SlidingPanel isShown={sidePanel} onClose={() => setSidePanel(false)}>
                 <WorkflowTemplateCreator namespace={namespace} onCreate={wf => navigation.goto(uiUrl(`workflow-templates/${wf.metadata.namespace}/${wf.metadata.name}`))} />

--- a/ui/src/workflows/components/workflows-list/workflows-list.tsx
+++ b/ui/src/workflows/components/workflows-list/workflows-list.tsx
@@ -8,6 +8,7 @@ import {uiUrl} from '../../../shared/base';
 import {CostOptimisationNudge} from '../../../shared/components/cost-optimisation-nudge';
 import {ErrorNotice} from '../../../shared/components/error-notice';
 import {ExampleManifests} from '../../../shared/components/example-manifests';
+import {FiltersCollapseToggle} from '../../../shared/components/filters-collapse-toggle';
 import {openLinkWithKey} from '../../../shared/components/links';
 import {Loading} from '../../../shared/components/loading';
 import {PaginationPanel} from '../../../shared/components/pagination-panel';
@@ -23,6 +24,7 @@ import {Pagination, parseLimit} from '../../../shared/pagination';
 import {ScopedLocalStorage} from '../../../shared/scoped-local-storage';
 import {services} from '../../../shared/services';
 import {useCollectEvent} from '../../../shared/use-collect-event';
+import {useFiltersCollapsed} from '../../../shared/use-filters-collapsed';
 import useTimestamp, {TIMESTAMP_KEYS} from '../../../shared/use-timestamp';
 import * as Actions from '../../../shared/workflow-operations-map';
 import {WorkflowCreator} from '../workflow-creator';
@@ -65,6 +67,7 @@ export function WorkflowsList() {
     const {navigation} = useContext(Context);
 
     const isFirstRender = useRef(true);
+    const [filtersCollapsed, toggleFiltersCollapsed] = useFiltersCollapsed();
     const [namespace, setNamespace] = useState(nsUtils.getNamespace(routeParams.namespace) || '');
     const [sidePanel, setSidePanel] = useState(queryParams.get('sidePanel') || '');
     const [pagination, setPagination] = useState<Pagination>(() => {
@@ -241,8 +244,9 @@ export function WorkflowsList() {
                 disabledActions={batchActionDisabled}
                 loadWorkflows={clearSelectedWorkflows}
             />
-            <div className={`row ${selectedWorkflows.size === 0 ? '' : 'pt-60'}`}>
+            <div className={`row wf-list-layout ${filtersCollapsed ? 'wf-list-layout--collapsed' : ''} ${selectedWorkflows.size === 0 ? '' : 'pt-60'}`}>
                 <div className='columns small-12 xlarge-2'>
+                    <FiltersCollapseToggle collapsed={false} onToggle={toggleFiltersCollapsed} />
                     <WorkflowsSummaryContainer workflows={workflows} />
                     <div>
                         <WorkflowFilters
@@ -380,6 +384,7 @@ export function WorkflowsList() {
                         </>
                     )}
                 </div>
+                {filtersCollapsed && <FiltersCollapseToggle collapsed={true} onToggle={toggleFiltersCollapsed} />}
             </div>
             <SlidingPanel isMiddle={true} isShown={!!sidePanel} onClose={() => setSidePanel('')}>
                 {sidePanel === 'submit-new-workflow' && (


### PR DESCRIPTION
Fixes #TODO

### Motivation

The filter panel sits on the left and eats horizontal space, so the table gets cramped and truncates columns. Moving it to the right and letting people collapse it gives that width back to the data when filters aren't needed.

### Modifications

The filter sidebar moves from the left to the right on the workflows, cron workflows, templates, and reports views. The move is done with CSS `order` rather than reordering the DOM. A collapse/expand control lets you tuck the panel away to reclaim its width for the table, and the collapsed state is remembered in `localStorage`.

Expanded:

![Workflows list, filters expanded on the right](https://raw.githubusercontent.com/tico24/argo-workflows/pr-assets/prs/prB-filter__workflows-list__expanded.png)

Collapsed:

![Workflows list, filters collapsed](https://raw.githubusercontent.com/tico24/argo-workflows/pr-assets/prs/prB-filter__workflows-list__collapsed.png)

### Verification

- `yarn build` and `yarn test` are green (110 tests passing).
- Lint is green.
- Exercised against a live backend with no observed regressions.

### Documentation

None needed — this is a purely visual change.

### AI

Generative AI was used to help prepare this PR (code, commit messages, and description), under human direction, review, and testing.
