### PR TITLE
feat(ui): add optional dark mode (system default, toggle, persisted)

### DIFF
--- a/.features/pending/ui-dark-mode.md
+++ b/.features/pending/ui-dark-mode.md
@@ -1,0 +1,6 @@
+Description: Add an optional dark mode (system default, toggle, persisted)
+Authors: [Tim Collins](https://github.com/tico24)
+Component: General
+Issues: 5037
+
+Adds dark mode (closes #5037). Follows your OS setting by default, with a toggle to force light or dark that sticks via localStorage. The theme's applied to the root element before the app mounts so there's no white flash on load. Both themes pass AA contrast.

--- a/ui/src/app-router.tsx
+++ b/ui/src/app-router.tsx
@@ -22,9 +22,11 @@ import sensors from './sensors';
 import {uiUrl} from './shared/base';
 import {ChatButton} from './shared/components/chat-button';
 import ErrorBoundary from './shared/components/error-boundary';
+import {ThemeToggle} from './shared/components/theme-toggle';
 import {Version} from './shared/models';
 import * as nsUtils from './shared/namespaces';
 import {services} from './shared/services';
+import {useTheme} from './shared/use-theme';
 import userinfo from './userinfo';
 import {Widgets} from './widgets/widgets';
 import workflowEventBindings from './workflow-event-bindings';
@@ -53,6 +55,12 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
     const [version, setVersion] = useState<Version>();
     const [namespace, setNamespace] = useState<string>();
     const [navBarBackgroundColor, setNavBarBackgroundColor] = useState<string>();
+    // Theme state lives high in the router so toggling never remounts the route
+    // tree (filter state etc. is preserved). useTheme also writes the
+    // .theme-light/.theme-dark class onto document.documentElement so routes
+    // rendered OUTSIDE the argo-ui Layout (login, widgets, top-level Popup,
+    // notifications) are themed consistently.
+    const [themeMode, setThemeMode, resolvedTheme] = useTheme();
     const setError = (error: Error) => {
         notificationsManager.show({
             content: 'Failed to load version/info ' + error,
@@ -99,6 +107,7 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
                         path='*'
                         element={
                             <Layout
+                                theme={resolvedTheme}
                                 navBarStyle={{backgroundColor: navBarBackgroundColor}}
                                 navItems={[
                                     {
@@ -189,6 +198,7 @@ export function AppRouter({popupManager, history, notificationsManager}: {popupM
                                     </Routes>
                                 </ErrorBoundary>
                                 <ChatButton />
+                                <ThemeToggle mode={themeMode} resolved={resolvedTheme} onChange={setThemeMode} />
                                 {version && modals && <ModalSwitch version={version.version} modals={modals} />}
                             </Layout>
                         }

--- a/ui/src/assets/scss/_dark-surfaces.scss
+++ b/ui/src/assets/scss/_dark-surfaces.scss
@@ -1,0 +1,177 @@
+// _dark-surfaces.scss — DARK MODE re-theming for app-local surfaces that hardcode
+// LIGHT colors (white / argo-color-gray-* literals) and therefore do NOT follow
+// the --awf-* token overrides in _tokens-dark.scss.
+//
+// FEATURE: optional dark mode. A handful of app-local component SCSS files paint
+// `background-color: white` (and argo gray literals) directly instead of via
+// var(--awf-*) — most visibly the workflow-details DAG graph-options panels and
+// the node-search input, which otherwise render as glaring white slabs on the
+// dark canvas. We do NOT edit those baseline files (zero light-mode regression);
+// instead we override the SAME selectors here, scoped under `.theme-dark`, so
+// the surfaces follow the dark theme. Loaded AFTER the component partials by
+// source order; `.theme-dark <sel>` (0,1,1) also out-specifies the bare class.
+//
+// PAINT-ONLY: background / color / border-color / box-shadow / fill / stroke
+// only — no geometry. Sass hygiene: plain CSS + var() tokens, no @import / no
+// darken()/lighten().
+
+.theme-dark {
+    // --- DAG graph-options + render-options floating panels --------------
+    // graph-panel.scss:36 and workflow-dag.scss:10 hardcode white + a light
+    // gray box-shadow. Re-skin them as a dark elevated card.
+    .graph-options-panel,
+    .workflow-dag-render-options-panel {
+        background-color: var(--awf-surface, #1f2228);
+        box-shadow: var(--awf-shadow-pop, 0 4px 16px rgba(0, 0, 0, 0.6));
+        color: var(--awf-text, #e3e8ec);
+
+        a,
+        div.argo-dropdown {
+            color: var(--awf-muted-aa, #aeb8bf);
+
+            &.active {
+                background-color: var(--awf-tint-2, #12333a);
+                border-color: var(--awf-hairline, #353a42);
+            }
+
+            &:hover {
+                color: var(--awf-text, #e3e8ec);
+            }
+        }
+    }
+
+    // The node-search input inside the graph options panel (TextInput → a plain
+    // input). argo-ui themify covers .argo-field, but this raw input needs the
+    // dark surface explicitly so it does not read as a white box.
+    .node-search-bar input,
+    .graph-options-panel input {
+        background-color: var(--awf-tint-1, #181b21);
+        color: var(--awf-text, #e3e8ec);
+        border-color: var(--awf-hairline, #353a42);
+
+        &::placeholder {
+            color: var(--awf-muted, #9aa6ad);
+        }
+    }
+
+    // --- DAG canvas glyph/label legibility on the dark canvas ------------
+    // The graph node-label / edge text default to argo gray-8 (near-black),
+    // invisible on the dark canvas. a11y-paint already retargets .node-label /
+    // edge text via --awf-node-label-text; reassert here for the edge text +
+    // group outlines so the whole graph reads on dark.
+    .graph {
+        .edge text {
+            fill: var(--awf-node-label-text, #c3ccd2);
+        }
+
+        .group rect {
+            stroke: var(--awf-hairline, #353a42);
+        }
+    }
+
+    // --- Workflow timeline surface --------------------------------------
+    // workflow-timeline.scss:5 hardcodes `background: white`.
+    .workflow-timeline {
+        background: var(--awf-surface, #1f2228);
+        color: var(--awf-text, #e3e8ec);
+
+        // DEFECT 2: the top time-axis ruler/header strip stays LIGHT in dark
+        // mode. workflow-timeline.scss:22 hardcodes the header band background
+        // to $argo-color-gray-3 (#DEE6EB, light) and the time labels (the
+        // &__start-line__time, :69) to $argo-color-gray-5 (#8FA4B1). Neither is
+        // a --awf-* token, so the dark theme never reaches them. Re-skin the
+        // header band as a dark chrome strip with light AA labels.
+        &__row--header {
+            // dark strip, one step below the surface so it reads as a ruler
+            background-color: var(--awf-chrome, #0c0d11);
+        }
+
+        &__start-line__time {
+            // light AA time labels on the dark strip (>= 7:1 on #0c0d11)
+            color: var(--awf-muted-aa, #aeb8bf);
+        }
+    }
+
+    // --- DEFECT 1: workflow-details summary node-info attribute grid -----
+    // workflow-details.scss:108 hardcodes the grid text color to
+    // $argo-color-gray-8 (#363C4A, near-black) and the artifact-row text the
+    // same. The panel SURFACE is already dark (argo-ui themify white-box), so
+    // the near-black key/value text renders effectively INVISIBLE on dark.
+    // Neither uses a --awf-* token. Retarget the grid + related node-info text
+    // to the light body/muted tokens so labels + values are legible (AA).
+    .workflow-details__attribute-grid,
+    .workflow-node-info .artifact-row,
+    .workflow-node-info .row.header {
+        color: var(--awf-text, #e3e8ec);
+    }
+
+    // The odd (label) cells read as a secondary "key"; keep them legible-muted
+    // so the value column stays the emphasis. Even cells inherit --awf-text.
+    .workflow-details__attribute-grid > *:nth-child(odd) {
+        color: var(--awf-muted-aa, #aeb8bf);
+    }
+
+    // --- Native form controls -------------------------------------------
+    // Bare native checkboxes/radios (e.g. the workflows-list row-select column)
+    // render as bright white boxes on the dark canvas. `accent-color` is a
+    // paint-only property that tints the native control's fill/checkmark to the
+    // teal accent and lets the UA pick an appropriate dark control surface, so
+    // the boxes read as part of the dark theme without restyling the widget.
+    input[type='checkbox'],
+    input[type='radio'] {
+        accent-color: var(--awf-accent, #2ec6d8);
+    }
+
+    // --- DEFECT 3: pagination "results per page" native <select> --------
+    // PaginationPanel renders a bare native <select class="small"> inside
+    // `.wf-pagination`. Its CONTROL FACE picks up a light/gray UA default on
+    // the dark canvas. Paint the control face dark with light text. (The native
+    // option-list popup is OS-controlled — color-scheme:dark already hints it;
+    // we only style the closed control face here.)
+    .wf-pagination select {
+        background-color: var(--awf-tint-1, #181b21);
+        color: var(--awf-text, #e3e8ec);
+        border-color: var(--awf-hairline, #353a42);
+    }
+
+    // --- DEFECT 4: list row NAME link is muted/dim ----------------------
+    // workflow-template-list.scss / cron-workflow-list.scss set the row name
+    // <Link> to $argo-color-gray-6 (#6D7F8B). On the dark surface that reads
+    // dimmer (~3.5:1) than the sibling namespace/created cells (which use
+    // --awf-text). Bump the name link to the AA link teal so it matches the
+    // legibility of the other row text and reads as the clickable name.
+    .workflow-templates-list__row-container a,
+    .cron-workflows-list__row-container a {
+        color: var(--awf-link-aa, #3fc6d6);
+
+        &:hover {
+            color: var(--awf-link-aa-hover, #6ad8e6);
+        }
+    }
+
+    // --- Help + login standalone surfaces -------------------------------
+    // help.scss:8 / login.scss:44 hardcode #fff. login renders OUTSIDE the
+    // argo-ui Layout, but the .theme-dark class is on <html> so this still
+    // applies.
+    .help-page .white-box,
+    .login__content,
+    .login form {
+        background-color: var(--awf-surface, #1f2228);
+        color: var(--awf-text, #e3e8ec);
+    }
+
+    // --- Collapsed filters edge tab -------------------------------------
+    // The neutral collapse handle (from _modern-filters-layout.scss) sits on
+    // the dark surface with the dark hairline and the dark link-teal hover
+    // accent. The base values come from _tokens-dark.scss / the var() flips,
+    // but the collapsed edge tab needs its surface + border re-pointed so it
+    // reads against the dark canvas, with the quiet teal accent on hover.
+    .filters-collapse-toggle--collapsed {
+        background: var(--awf-surface);
+        border-color: var(--awf-hairline);
+
+        &:hover {
+            border-color: var(--awf-accent);
+        }
+    }
+}

--- a/ui/src/assets/scss/_theme-toggle.scss
+++ b/ui/src/assets/scss/_theme-toggle.scss
@@ -1,0 +1,59 @@
+// _theme-toggle.scss — the dark-mode toggle control.
+//
+// FEATURE: optional dark mode. The toggle is rendered app-side as a Layout child
+// (see app-router.tsx) and pinned to the BOTTOM of the navy icon rail so it lives
+// in the existing chrome without forking argo-ui's nav-bar. It mirrors the rail's
+// icon-button rhythm (muted icon, brighter on hover/focus) and works in BOTH
+// themes because the rail is dark in both.
+//
+// Sass hygiene: plain CSS + var() tokens. No @import, no darken()/lighten().
+
+.theme-toggle {
+    position: fixed;
+    left: 0;
+    bottom: var(--awf-space-3, 12px);
+    // argo-ui's nav rail is z-index 11 ($nav-z-index in config.scss); sit one
+    // above it so the toggle is clickable/visible at the rail's bottom, but well
+    // below the modal/sliding-panel layer.
+    z-index: 12;
+    width: var(--awf-nav-width, 60px);
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+    border: none;
+    background: transparent;
+    color: var(--awf-nav-inactive, #818d94);
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    transition: color 0.15s ease, background-color 0.15s ease;
+
+    i {
+        // Square the glyph box so the icon optically centres on the rail.
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1em;
+        height: 1em;
+    }
+
+    &:hover,
+    &:focus-visible {
+        // Lift to the active rail accent on hover/focus for a clear affordance.
+        color: var(--awf-active, #1fbdd0);
+        background-color: rgba(255, 255, 255, 0.06);
+    }
+
+    // When an explicit (non-auto) override is active, tint the icon toward the
+    // resolved theme so the current choice is glanceable on the rail.
+    &--light i {
+        color: #f4c542; // warm sun
+    }
+
+    &--dark i {
+        color: #8fb7ff; // cool moon
+    }
+}

--- a/ui/src/assets/scss/_tokens-dark.scss
+++ b/ui/src/assets/scss/_tokens-dark.scss
@@ -1,0 +1,158 @@
+// _tokens-dark.scss — DARK MODE token overrides for the UI modernization restyle.
+//
+// FEATURE: optional dark mode. The restyle's own design tokens live as a LIGHT,
+// unconditional `:root{}` block in _tokens.scss. Because every painted restyle
+// node reads its colours as `var(--awf-*, <fallback>)`, and the `.theme-dark`
+// ancestor class is on <html> (set by useTheme + the index.html pre-mount
+// bootstrap) and by argo-ui's Layout, REDEFINING the --awf-* tokens under a
+// `.theme-dark` scope re-themes the whole restyle surface (nav rail, top bar,
+// cards, the right-hand filter sidebar, buttons, inputs, tabs, tables/rows,
+// status pills, the courier log console, summary box, charts) with NO
+// per-component edits.
+//
+// SPECIFICITY: `.theme-dark` (0,1,0) ties `:root` (0,1,0); this partial is
+// @forwarded AFTER 'tokens' in app-restyle.scss, so it wins by SOURCE ORDER.
+// Since `.theme-dark` is an ANCESTOR of every painted node, the var() lookups
+// resolve to these dark values whenever the class is present, and resolve to
+// the unchanged :root light values otherwise — so LIGHT mode is byte-for-byte
+// preserved (zero regression).
+//
+// AA: every text / link / status / focus value below is verified >= 4.5:1
+// (4.5 normal text, 3:1 large/UI) against its ACTUAL dark background, including
+// the composited rgba pill tints. See the ratios noted inline.
+//
+// Sass hygiene: plain CSS custom properties + var() only. No @import, no
+// darken()/lighten(); coordinated with argo-ui's legacy themify() dark palette
+// ($dark-theme-background-1 #100f0f / -2 #303237) so restyle cards do not clash
+// with legacy themed surfaces on shared pages.
+
+.theme-dark {
+    // Tell the UA to render native controls (checkboxes, radios, scrollbars,
+    // date/time pickers, default form widgets) in their DARK variant. This is a
+    // paint-only hint that fixes bright-white native checkboxes / scrollbars on
+    // the dark canvas with no per-widget restyling.
+    color-scheme: dark;
+
+    // --- Surfaces & structure --------------------------------------------
+    // Calm, slightly blue-grey dark canvas (not pure black). Coordinated with
+    // argo-ui dark bg-1 #100f0f / bg-2 #303237 but a touch warmer/neutral so
+    // restyle cards read as a clear elevation step above the canvas.
+    --awf-canvas: #101216; // app background (sits under cards; one clear step below surface)
+    --awf-surface: #1f2228; // cards, panels, rows, top-bar, inputs (12.9:1 text)
+    --awf-text: #e3e8ec; // body text (12.92:1 on surface)
+    --awf-heading: #f3f6f8; // headings (14.68:1 on surface)
+    --awf-muted: #9aa6ad; // secondary text (6.40:1 on surface)
+    --awf-hairline: #353a42; // 1px separators / borders (matches argo dark gray)
+    --awf-accent: #2ec6d8; // brighter teal accent for dark (icons / borders / large)
+    --awf-active: #3fd0e0; // brighter teal for active/hover chrome
+    --awf-tint-1: #181b21; // faint wash → log console + hover surface
+    --awf-tint-2: #12333a; // stronger teal wash (selected / strong hover)
+    --awf-chrome: #0c0d11; // dark chrome (already dark; deepen slightly)
+
+    // --- AA text variants (>= 4.5:1 on dark surface) ---------------------
+    --awf-muted-aa: #aeb8bf; // muted text, AA on surface (7.90:1) and canvas (8.80:1)
+    --awf-link-aa: #3fc6d6; // link teal, AA on surface (7.79:1)
+    --awf-link-aa-hover: #6ad8e6; // lighter on hover (still AA, reads as lift)
+    --awf-focus-ring: #3fd0e0; // visible focus outline on dark (8.58:1)
+
+    // --- Nav rail --------------------------------------------------------
+    // The icon rail is intentionally dark in BOTH themes. Keep the navy but
+    // deepen it a touch so it reads as part of the dark chrome rather than a
+    // bright slab. Inactive/active label colours already clear AA on it.
+    --awf-nav-bg: #0c1f29; // slightly deeper navy than light mode (#0f2733)
+    --awf-nav-inactive: #93a0a8; // muted slate label, AA on the navy rail
+    --awf-nav-active-icon: #fe733f; // keep the orange active-icon accent
+
+    // --- Status text (AA on the dark composited pill tints) --------------
+    // Lighter AA-on-dark variants (the light values FAIL on dark). Ratios are
+    // against the rgba tint composited over --awf-surface (see _modern-status-pill
+    // / _modern-cards alpha bumps below): all >= 5.0:1.
+    --awf-status-succeeded-text: #3ddc97; // 6.32:1
+    --awf-status-running-text: #5bc8f5; // 5.72:1
+    --awf-status-failed-text: #f0959c; // 5.03:1
+    --awf-status-warning-text: #e8c14a; // 5.50:1
+    --awf-status-pending-text: #b6c0c7; // 6.30:1
+
+    // a11y-paint references these for the Unknown pill + node label text.
+    --awf-status-unknown-text: #b6c0c7;
+    --awf-node-label-text: #c3ccd2;
+
+    // Dot/pill outline tokens (a11y-paint) — lift to AA-on-dark amber/slate.
+    --awf-status-warning-outline: #e8c14a;
+    --awf-status-pending-outline: #b6c0c7;
+
+    // --- Accent interaction states ---------------------------------------
+    // The solid-teal primary FILL sits behind a near-white label; use an
+    // AA-clean teal so white keeps >= 4.5:1 (white on #0c6f7b = 5.87:1).
+    --awf-accent-hover: #0c6f7b; // solid-teal primary hover/fill (white 5.87:1)
+    --awf-accent-active: #0a5f6a; // pressed solid teal (white 6.6:1)
+    --awf-ghost-hover: #15333a; // faint teal wash for ghost/secondary hover
+
+    // --- Neutral button system -------------------------------------------
+    // Neutral slate pill, one step lighter than the surface so it reads as a
+    // raised control, with a near-white label (10:1 AA).
+    --awf-btn-neutral: #3a4049; // resting neutral fill
+    --awf-btn-neutral-hover: #454c56; // hover: lighter
+    --awf-btn-neutral-active: #333942; // pressed: darker
+    --awf-btn-on-neutral: #f4f7f8; // near-white label (10:1 on fill)
+    --awf-btn-disabled-bg: #2a2e35; // muted dark disabled fill
+    --awf-btn-disabled-text: #7f8a92; // disabled label (3.86:1, UI/large)
+    --awf-teal-5: #2ec6d8; // outline border + focus ring on dark
+
+    // --- Elevation -------------------------------------------------------
+    // Deepen the shadow alpha so cards still read against the dark canvas.
+    --awf-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.5);
+    --awf-shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.45), 0 4px 10px rgba(0, 0, 0, 0.55);
+    --awf-shadow-pop: 0 4px 16px rgba(0, 0, 0, 0.6);
+
+    // --- Focus ring (brighter teal so the ring is visible on dark) -------
+    --awf-focus-ring-shadow: 0 0 0 3px rgba(63, 208, 224, 0.35);
+
+    // --- High-contrast / forced-colors max variants (dark) ---------------
+    // a11y-paint @media(prefers-contrast: more) reads these — give them
+    // brighter-than-base dark values so "more contrast" goes lighter on dark.
+    --awf-text-max: #ffffff;
+    --awf-muted-max: #d4dbe0;
+    --awf-link-max: #7fe0ee;
+    --awf-border-max: #5a636d;
+    --awf-status-pending-text-max: #d4dbe0;
+    --awf-status-running-text-max: #8fd6f7;
+    --awf-status-failed-text-max: #f6b3b8;
+    --awf-status-succeeded-text-max: #6fe6b4;
+    --awf-status-unknown-text-max: #d4dbe0;
+}
+
+// -----------------------------------------------------------------------------
+// STATUS PILL / BADGE BACKGROUNDS are rgba() LITERALS in _modern-status-pill.scss
+// and _modern-cards.scss (NOT tokens), so token overrides do not reach them. At
+// their light-mode alpha (0.14–0.18) they read as faint, barely-there chips on a
+// dark surface. Re-declare them here at a slightly HIGHER alpha so each phase
+// chip is a clear tinted dark chip, and so the composited contrast against the
+// (now lighter) AA status-text values stays >= 5:1. These are the SAME hues as
+// light mode — only the alpha changes — so the status language is consistent.
+// Scoped under `.theme-dark` and placed AFTER the .theme-dark token block so
+// they win by source order over the base pill rules.
+// -----------------------------------------------------------------------------
+.theme-dark {
+    .wf-phase-pill {
+        // Default / Unknown / Omitted neutral chip.
+        background-color: rgba(120, 140, 155, 0.22);
+    }
+
+    .wf-phase-pill--Succeeded {
+        background-color: rgba(24, 190, 148, 0.2);
+    }
+
+    .wf-phase-pill--Running {
+        background-color: rgba(13, 173, 234, 0.22);
+    }
+
+    .wf-phase-pill--Pending {
+        background-color: rgba(244, 192, 48, 0.22);
+    }
+
+    .wf-phase-pill--Failed,
+    .wf-phase-pill--Error {
+        background-color: rgba(233, 109, 118, 0.24);
+    }
+}

--- a/ui/src/assets/scss/app-restyle.scss
+++ b/ui/src/assets/scss/app-restyle.scss
@@ -13,6 +13,11 @@
 // so this entry adds ZERO new Sass deprecation warnings.
 
 @forward 'tokens';
+// FEATURE: dark mode token overrides. Forwarded immediately AFTER 'tokens' so
+// the `.theme-dark { --awf-*: ... }` block wins by source order over the equal-
+// specificity `:root` light block whenever the `.theme-dark` ancestor class is
+// present, and is inert (light preserved byte-for-byte) otherwise.
+@forward 'tokens-dark';
 @use 'font-override';
 
 // CASCADE OVERRIDE partials. These load AFTER argo-ui's main.scss (because this
@@ -91,3 +96,12 @@
 // order. Scoped to the page-level row via `.wf-list-layout > .columns` direct
 // children so nested filter rows are never reordered.
 @use 'modern-filters-layout';
+
+// FEATURE: dark-mode toggle control (pinned to the nav rail bottom). Loaded
+// last; paint/geometry of its own fixed box only.
+@use 'theme-toggle';
+
+// FEATURE: dark-mode re-theming for app-local surfaces that hardcode white /
+// argo gray literals (DAG graph-options panels, node-search input, timeline,
+// help/login). Scoped under `.theme-dark`; paint-only; inert in light mode.
+@use 'dark-surfaces';

--- a/ui/src/index.html
+++ b/ui/src/index.html
@@ -8,6 +8,26 @@
     <meta name="robots" content="noindex">
     <link rel="icon" type="image/png" href="assets/favicon/favicon-32x32.png" sizes="32x32">
     <link rel="icon" type="image/png" href="assets/favicon/favicon-16x16.png" sizes="16x16">
+    <script>
+        // Pre-mount theme bootstrap: apply the .theme-light/.theme-dark ancestor
+        // paint, so dark mode does not flash light (FOUC). Reads the same
+        // JSON-encoded 'theme' localStorage key as useTheme; default 'auto'.
+        // Resolution mirrors resolveTheme() in
+        // src/shared/use-theme.ts (resolveTheme).
+        (function () {
+            try {
+                var root = document.documentElement;
+                var raw = window.localStorage.getItem('theme');
+                var mode = raw ? JSON.parse(raw) : 'auto';
+                var dark = mode === 'dark' ||
+                    (mode !== 'light' &&
+                        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+                var resolved = dark ? 'dark' : 'light';
+                root.classList.remove('theme-light', 'theme-dark');
+                root.classList.add('theme-' + resolved);
+            } catch (e) { /* ignore: useTheme will apply the class on mount */ }
+        })();
+    </script>
 </head>
 
 <body>

--- a/ui/src/shared/components/theme-toggle.tsx
+++ b/ui/src/shared/components/theme-toggle.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import * as React from 'react';
+
+import {ResolvedTheme, ThemeMode} from '../use-theme';
+
+interface ThemeToggleProps {
+    mode: ThemeMode;
+    resolved: ResolvedTheme;
+    onChange: (mode: ThemeMode) => void;
+}
+
+// The three explicit modes the toggle cycles through, in order. 'auto' follows
+// the OS preference (the default); 'light' / 'dark' are explicit user overrides
+// that persist and win over the OS.
+const ORDER: ThemeMode[] = ['auto', 'light', 'dark'];
+
+const ICON: Record<ThemeMode, string> = {
+    auto: 'fa-circle-half-stroke',
+    light: 'fa-sun',
+    dark: 'fa-moon'
+};
+
+const LABEL: Record<ThemeMode, string> = {
+    auto: 'Theme: system',
+    light: 'Theme: light',
+    dark: 'Theme: dark'
+};
+
+// ThemeToggle is a single control pinned to the bottom of the navy icon rail
+// (it mirrors the rail's icon-button rhythm). Clicking it cycles
+// system -> light -> dark and persists the choice. The icon reflects the chosen
+// MODE; auto shows a half-circle, and we add a data attribute carrying the
+// RESOLVED theme so the rail's active-state styling can hint the live theme.
+export function ThemeToggle({mode, resolved, onChange}: ThemeToggleProps) {
+    const next = ORDER[(ORDER.indexOf(mode) + 1) % ORDER.length];
+    const title = mode === 'auto' ? `${LABEL[mode]} (${resolved})` : LABEL[mode];
+    return (
+        <button
+            type='button'
+            className={classNames('theme-toggle', `theme-toggle--${mode}`)}
+            onClick={() => onChange(next)}
+            data-resolved={resolved}
+            aria-label={title}
+            title={title}>
+            <i className={classNames('fas', ICON[mode])} aria-hidden='true' />
+        </button>
+    );
+}

--- a/ui/src/shared/use-theme.test.tsx
+++ b/ui/src/shared/use-theme.test.tsx
@@ -1,0 +1,119 @@
+import {act, renderHook} from '@testing-library/react';
+
+import {applyThemeClass, resolveTheme, systemPrefersDark, THEME_KEY, useTheme} from './use-theme';
+
+// Minimal matchMedia mock that lets a test flip the OS preference and fire the
+// 'change' event registered by useTheme.
+function mockMatchMedia(initialDark: boolean) {
+    let matches = initialDark;
+    const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+    const mql = {
+        get matches() {
+            return matches;
+        },
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => listeners.push(cb),
+        removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => {
+            const i = listeners.indexOf(cb);
+            if (i >= 0) listeners.splice(i, 1);
+        },
+        addListener: (cb: (e: MediaQueryListEvent) => void) => listeners.push(cb),
+        removeListener: (cb: (e: MediaQueryListEvent) => void) => {
+            const i = listeners.indexOf(cb);
+            if (i >= 0) listeners.splice(i, 1);
+        }
+    };
+    (window as any).matchMedia = jest.fn().mockReturnValue(mql);
+    return {
+        setDark(v: boolean) {
+            matches = v;
+            listeners.forEach(cb => cb({matches: v} as MediaQueryListEvent));
+        }
+    };
+}
+
+describe('resolveTheme', () => {
+    it('explicit light/dark override always wins regardless of OS', () => {
+        expect(resolveTheme('light', true)).toBe('light');
+        expect(resolveTheme('dark', false)).toBe('dark');
+    });
+
+    it('auto follows the OS preference', () => {
+        expect(resolveTheme('auto', true)).toBe('dark');
+        expect(resolveTheme('auto', false)).toBe('light');
+    });
+});
+
+describe('applyThemeClass', () => {
+    it('sets exactly one theme class on the document root', () => {
+        applyThemeClass('dark');
+        expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+        expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+        applyThemeClass('light');
+        expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+        expect(document.documentElement.classList.contains('theme-dark')).toBe(false);
+    });
+});
+
+describe('useTheme', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        document.documentElement.classList.remove('theme-light', 'theme-dark');
+    });
+
+    it('defaults to auto and follows a dark OS on first load', () => {
+        mockMatchMedia(true);
+        const {result} = renderHook(() => useTheme());
+        const [mode, , resolved] = result.current;
+        expect(mode).toBe('auto');
+        expect(resolved).toBe('dark');
+        expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+    });
+
+    it('defaults to auto and follows a light OS on first load', () => {
+        mockMatchMedia(false);
+        const {result} = renderHook(() => useTheme());
+        expect(result.current[2]).toBe('light');
+        expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+    });
+
+    it('persists an explicit override and restores it on reload', () => {
+        mockMatchMedia(true); // OS is dark...
+        const first = renderHook(() => useTheme());
+        act(() => first.result.current[1]('light')); // ...but user picks light
+        expect(first.result.current[2]).toBe('light');
+        expect(JSON.parse(window.localStorage.getItem(THEME_KEY)!)).toBe('light');
+
+        // Simulate reload: a fresh hook reads the stored override and ignores OS.
+        const second = renderHook(() => useTheme());
+        expect(second.result.current[0]).toBe('light');
+        expect(second.result.current[2]).toBe('light');
+    });
+
+    it('reacts live to OS changes while in auto mode', () => {
+        const os = mockMatchMedia(false);
+        const {result} = renderHook(() => useTheme());
+        expect(result.current[2]).toBe('light');
+        act(() => os.setDark(true));
+        expect(result.current[2]).toBe('dark');
+        expect(document.documentElement.classList.contains('theme-dark')).toBe(true);
+    });
+
+    it('does NOT follow OS changes once an explicit override is set', () => {
+        const os = mockMatchMedia(false);
+        const {result} = renderHook(() => useTheme());
+        act(() => result.current[1]('dark')); // explicit dark
+        act(() => os.setDark(true)); // OS goes dark too
+        act(() => os.setDark(false)); // OS goes light — override must hold
+        expect(result.current[2]).toBe('dark');
+    });
+});
+
+describe('systemPrefersDark', () => {
+    it('returns the matchMedia result', () => {
+        mockMatchMedia(true);
+        expect(systemPrefersDark()).toBe(true);
+        mockMatchMedia(false);
+        expect(systemPrefersDark()).toBe(false);
+    });
+});

--- a/ui/src/shared/use-theme.ts
+++ b/ui/src/shared/use-theme.ts
@@ -1,0 +1,89 @@
+import {useEffect, useState} from 'react';
+
+import {useLocalStorage} from './use-local-storage';
+
+// FEATURE: optional dark mode.
+//
+// ONE shared localStorage key for the user's theme preference. JSON-encoded by
+// useLocalStorage, mirroring the modal-suppression / filters-collapsed
+// conventions already used in the codebase. Value is one of the ThemeMode
+// strings below.
+//
+// Resolution order:
+//   1. explicit user override ('light' | 'dark') always wins;
+//   2. 'auto' (the DEFAULT) follows the OS via prefers-color-scheme, and reacts
+//      live to OS changes.
+// Default mode is 'auto' so first load (with no stored choice) follows the OS
+// and the light baseline is byte-for-byte preserved on a light OS.
+export const THEME_KEY = 'theme';
+
+export type ThemeMode = 'light' | 'dark' | 'auto';
+export type ResolvedTheme = 'light' | 'dark';
+
+const DARK_QUERY = '(prefers-color-scheme: dark)';
+
+// systemPrefersDark reads the OS preference synchronously. Guarded for non-DOM
+// (test/SSR) environments where matchMedia may be absent.
+export function systemPrefersDark(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return false;
+    }
+    return window.matchMedia(DARK_QUERY).matches;
+}
+
+// resolveTheme maps a stored mode + the current OS preference onto the concrete
+// theme that should be painted.
+export function resolveTheme(mode: ThemeMode, prefersDark: boolean): ResolvedTheme {
+    if (mode === 'light' || mode === 'dark') {
+        return mode;
+    }
+    return prefersDark ? 'dark' : 'light';
+}
+
+// applyThemeClass writes the argo-ui theme ancestor class onto the document
+// root so that legacy themify() rules AND the restyle's `.theme-dark` token
+// overrides resolve — including content rendered OUTSIDE the argo-ui Layout
+// (login, widgets, top-level Popup, notifications, portals).
+export function applyThemeClass(resolved: ResolvedTheme): void {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    const root = document.documentElement;
+    root.classList.remove('theme-light', 'theme-dark');
+    root.classList.add('theme-' + resolved);
+}
+
+// useTheme centralises mode persistence, OS-preference resolution, live OS
+// change reaction (auto mode only), and applying the root ancestor class.
+// Returns [mode, setMode, resolved]. Kept high in app-router so toggling the
+// theme never remounts route/filter components.
+export function useTheme(): [ThemeMode, (mode: ThemeMode) => void, ResolvedTheme] {
+    const [mode, setMode] = useLocalStorage<ThemeMode>(THEME_KEY, 'auto');
+    const [prefersDark, setPrefersDark] = useState<boolean>(() => systemPrefersDark());
+
+    // React to OS changes so 'auto' mode follows the system live.
+    useEffect(() => {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return undefined;
+        }
+        const mql = window.matchMedia(DARK_QUERY);
+        const onChange = (e: MediaQueryListEvent) => setPrefersDark(e.matches);
+        // addEventListener is the modern API; older Safari only has addListener.
+        if (typeof mql.addEventListener === 'function') {
+            mql.addEventListener('change', onChange);
+            return () => mql.removeEventListener('change', onChange);
+        }
+        mql.addListener(onChange);
+        return () => mql.removeListener(onChange);
+    }, []);
+
+    const resolved = resolveTheme(mode, prefersDark);
+
+    // Apply the class to the document root whenever the resolved theme changes,
+    // so routes rendered outside argo-ui's Layout are themed too.
+    useEffect(() => {
+        applyThemeClass(resolved);
+    }, [resolved]);
+
+    return [mode, setMode, resolved];
+}


### PR DESCRIPTION
Fixes #5037

### Motivation

Dark mode has been a long-standing request (#5037). This adds an optional dark theme that follows your OS setting by default and can be overridden with a toggle.

### Modifications

The UI defaults to your operating system preference via `prefers-color-scheme`. A toggle lets you force light or dark instead, and that choice sticks via `localStorage`. The theme is applied to the root element before the app mounts, so there's no white flash on load. It builds on the existing theme mechanism with dark token overrides; light mode is unchanged, and both themes pass AA contrast.

Dark mode, filters expanded:

![Workflows list in dark mode, filters expanded](https://raw.githubusercontent.com/tico24/argo-workflows/pr-assets/prs/prC-dark__workflows-list__expanded.png)

Dark mode, filters collapsed:

![Workflows list in dark mode, filters collapsed](https://raw.githubusercontent.com/tico24/argo-workflows/pr-assets/prs/prC-dark__workflows-list__collapsed.png)

### Verification

- `yarn build` and `yarn test` are green (119 tests passing).
- Lint is green.
- Exercised against a live backend with no observed regressions.

### Documentation

Dark mode is discoverable via the toggle in the UI, so no separate documentation is needed.

### AI

Generative AI was used to help prepare this PR (code, commit messages, and description), under human direction, review, and testing.
